### PR TITLE
typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1096,7 +1096,7 @@ version when:
 
 1. A critical bug is discovered.
 2. There has been a lot of minor changes.
-3. A framework did a incompatible update.
+3. A framework did an incompatible update.
 4. A new framework is added
 5. People ask for it.
 


### PR DESCRIPTION
`a` -> `an`
