### PR TITLE
Fix SockJS reconnect

### DIFF
--- a/transformers/sockjs/client.js
+++ b/transformers/sockjs/client.js
@@ -45,7 +45,7 @@ module.exports = function client() {
       var event = e.code === 1002 ? 'error' : 'end';
       setTimeout(function timeout() {
         primus.emit('incoming::'+ event, e);
-      });
+      }, 0);
     };
     socket.onmessage = primus.emits('data', function parse(evt) {
       return evt.data;


### PR DESCRIPTION
Fixes #32 
SockJS never sends an error event, instead it always sends a close event. In the event the server disconnects (e.g. server crash), primus would attempt to reconnect but only try once because it expects an error event on any failed reconnect attempts.

This change will correctly send the error event when the initial SockJS connection fails, which is always the reconnection scenario for SockJS.
