### PR TITLE
Send back 401 error on upgrade

### DIFF
--- a/transformer.js
+++ b/transformer.js
@@ -171,6 +171,14 @@ Transformer.prototype.upgrade = function upgrade(req, socket, head) {
   this.primus.auth(req, function authorized(err) {
     if (!err) return transformer.emit('upgrade', req, socket, buffy, noop);
 
+    var message = JSON.stringify({ error: err.message || err });
+
+    socket.write('HTTP/' + req.httpVersion + ' 401 Unauthorized\r\n');
+    socket.write('Connection: close\r\n');
+    socket.write('Content-Type: application/json\r\n');
+    socket.write('Content-Length: ' + message.length + '\r\n');
+    socket.write('\r\n');
+    socket.write(message);
     socket.destroy();
   });
 };


### PR DESCRIPTION
request already sends back 401 but upgrade does not.
This gives the client a chance to differentiate between auth failure and connection/server fail
