### PR TITLE
Ensure that the pathname is not null

### DIFF
--- a/transformer.js
+++ b/transformer.js
@@ -195,8 +195,9 @@ Transformer.prototype.upgrade = function upgrade(req, socket, head) {
 Transformer.prototype.test = function test(req) {
   req.uri = url(req.url);
 
-  var route = this.primus.pathname
-    , accepted = req.uri.pathname.slice(0, route.length) === route;
+  var pathname = req.uri.pathname || '/'
+    , route = this.primus.pathname
+    , accepted = pathname.slice(0, route.length) === route;
 
   if (!accepted) this.emit('unknown', req);
 


### PR DESCRIPTION
The pathname of the request URL can be parsed as `null`:

``` javascript
var parse = require('url').parse
var url = 'ws://localhost:3000';
var pathname = parse(url).pathname  // pathname is null
```

When this happens the server crashes because we are trying to call `slice` on `null` `pathname`.

This patch ensures that there is a default value for `pathname` when it is parsed as `null`.
