### PR TITLE
Handle unhandled requests

### DIFF
--- a/test/transformer.base.js
+++ b/test/transformer.base.js
@@ -909,6 +909,18 @@ module.exports = function base(transformer) {
         );
       });
 
+      it('should handle requests to non existing routes captured by primus', function(done) {
+        this.timeout(100);
+        request(
+          'http://localhost:'+ server.portnumber + '/primus.js',
+          function (err, res, body) {
+            if (err) return done(err);
+
+            done();
+          }
+        );
+      });
+
       it('correctly parses the ip address', function (done) {
         primus.on('connection', function (spark) {
           var address = spark.address;

--- a/transformers/browserchannel/server.js
+++ b/transformers/browserchannel/server.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var http = require('http');
+
 /**
  * Minimum viable Browserchannel server for Node.js that works through the primus
  * interface.
@@ -44,10 +46,13 @@ module.exports = function server() {
   //
   // Listen to upgrade requests.
   //
-  this.on('request', function request(req, res, next) {
+  this.on('request', function request(req, res) {
     //
     // The browser.channel returns a middleware layer.
     //
-    this.service(req, res, next);
+    this.service(req, res, function next() {
+      res.writeHead(404, {'content-type': 'text/plain'});
+      res.end(http.STATUS_CODES[404]);
+    });
   });
 };

--- a/transformers/sockjs/server.js
+++ b/transformers/sockjs/server.js
@@ -10,7 +10,10 @@
 module.exports = function server() {
   var sockjs = require('sockjs')
     , Spark = this.Spark
-    , primus = this.primus;
+    , primus = this.primus
+    , prefix = primus.pathname;
+
+  if (prefix.charAt(prefix.length - 1) !== '/') prefix += '(?:[^/]+)?';
 
   this.service = sockjs.createServer();
 
@@ -46,7 +49,7 @@ module.exports = function server() {
   // Listen to upgrade requests.
   //
   var handle = this.service.listener({
-    prefix: primus.pathname,
+    prefix: prefix,
     log: this.logger.plain
   }).getHandler();
 

--- a/transformers/websockets/server.js
+++ b/transformers/websockets/server.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var parse = require('url').parse;
+var http = require('http')
+  , parse = require('url').parse;
 
 /**
  * Minimum viable WebSocket server for Node.js that works through the Primus
@@ -12,7 +13,6 @@ var parse = require('url').parse;
 module.exports = function server() {
   var WebSocketServer = require('ws').Server
     , logger = this.logger
-    , primus = this.primus
     , Spark = this.Spark;
 
   var service = this.service = new WebSocketServer({
@@ -54,6 +54,9 @@ module.exports = function server() {
       socket.on('error', spark.emits('error'));
       socket.on('message', spark.emits('data'));
     });
+  }).on('request', function request(req, res) {
+    res.writeHead(400, {'content-type': 'text/plain'});
+    res.end(http.STATUS_CODES[400]);
   });
 
   this.on('close', function close() {


### PR DESCRIPTION
Issue #120 happens when a request is captured by Primus and it is not correctly handled by the underlying realtime framework.
`Socket.IO` and `Engine.IO` correctly handle this.
This patch adds:
- a listener for normal requests in the `websockets` transformer which returns a `400` error status code
- a slightly modified prefix for the `sockjs` transformer to make it work like `Socket.IO`/`Engine.IO`
- a `next` handler which returns a `404` error status code when the `browserchannel` transformer returns `next()`
