### PR TITLE
Add a port number for zombie

### DIFF
--- a/primus.js
+++ b/primus.js
@@ -387,11 +387,11 @@ try {
     // and guess at a value from the 'href' value
     //
     if (!data.port) {
-        if (!data.href) data.href = ''
+        if (!data.href) data.href = '';
         if ((data.href.match(/\:/g) || []).length > 1) {
-            data.port = data.href.split(':')[2].split('/')[0]
+            data.port = data.href.split(':')[2].split('/')[0];
         } else {
-            data.port = ('https' === data.href.substr(0, 5)) ? 443 : 80
+            data.port = ('https' === data.href.substr(0, 5)) ? 443 : 80;
         }
     }
 


### PR DESCRIPTION
Fix for #136

If the browser does not provide us with a port number then it attempts to guess at it from the 'href' attribute.

Don't expect this to get merged, but I'd be grateful if it was :)
