### PR TITLE
[major] Better code-reuse by doing the client during the `close` event.

### DIFF
--- a/primus.js
+++ b/primus.js
@@ -665,11 +665,6 @@ Primus.prototype.initialise = function initialise(options) {
   primus.on('close', function end() {
     var readyState = primus.readyState;
 
-    //
-    // Always set the readyState to closed, and if we're still connecting, close
-    // the connection so we're sure that everything after this if statement block
-    // is only executed because our readyState is set to `open`.
-    //
     primus.readyState = Primus.CLOSED;
     if (readyState !== Primus.CLOSED) {
       primus.emit('readyStateChange');
@@ -689,6 +684,11 @@ Primus.prototype.initialise = function initialise(options) {
   primus.on('incoming::end', function end() {
     var readyState = primus.readyState;
 
+    //
+    // If we're still connecting, close the connection.
+    // Everything after the following if statements is only executed when
+    // the readyState is set to `open`.
+    //
     if (primus.timers.connect) primus.end();
     if (readyState !== Primus.OPEN) return;
 


### PR DESCRIPTION
Would love to get a second pair of eyes on this change. It would promote better code re-use but I don't know if I enable any race conditions or edge cases to exists as the clean up is now only done when the `close` event is emitted.
