### PR TITLE
Correctly handle requests when a middleware passes an error to its callback

### DIFF
--- a/middleware/error.js
+++ b/middleware/error.js
@@ -1,0 +1,39 @@
+'use strict';
+
+/**
+ * WARNING: this middleware is only used internally and does not follow the
+ * pattern of the other middleware. You should not use it.  
+ *
+ * Handle async middleware errors.
+ *
+ * @param {Error} err Error returned by the middleware.
+ * @param {Request} req HTTP request.
+ * @param {Response} res HTTP response.
+ * @api private
+ */
+module.exports = function error(err, req, res) {
+  var message = JSON.stringify({ error: err.message || err })
+    , length = Buffer.byteLength(message)
+    , code = err.statusCode || 500;
+
+  //
+  // As in the authorization middleware we need to handle two cases here:
+  // regular HTTP requests and upgrade requests.
+  //
+  if (res.setHeader) {
+    res.statusCode = code;
+    res.setHeader('Content-Type', 'application/json');
+    res.setHeader('Content-Length', length);
+
+    return res.end(message);
+  }
+  
+  res.write('HTTP/'+ req.httpVersion +' ');
+  res.write(code +' '+ require('http').STATUS_CODES[code] +'\r\n');
+  res.write('Connection: close\r\n');
+  res.write('Content-Type: application/json\r\n');
+  res.write('Content-Length: '+ length +'\r\n');
+  res.write('\r\n');
+  res.write(message);
+  res.destroy();
+};

--- a/test/transformer.base.js
+++ b/test/transformer.base.js
@@ -1003,7 +1003,7 @@ module.exports = function base(transformer, pathname, transformer_name) {
         );
       });
 
-      it('should handle requests to non existing routes captured by primus', function(done) {
+      it('handles requests to non existing routes captured by primus', function (done) {
         this.timeout(100);
         request(
           server.addr + '/primus.js',
@@ -1013,6 +1013,19 @@ module.exports = function base(transformer, pathname, transformer_name) {
             done();
           }
         );
+      });
+
+      it('correctly handles requests when a middleware returns an error', function (done) {
+        primus.before('foo', function foo(req, res, next) {
+          next(new Error('foo failed'));
+        });
+
+        primus.on('connection', function (spark) {
+          throw new Error('connection should not be triggered');
+        });
+
+        var socket = new Socket(server.addr, { strategy: false });
+        socket.on('end', done);
       });
 
       it('correctly parses the ip address', function (done) {

--- a/transformer.js
+++ b/transformer.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var querystring = require('querystring').parse
+var middlewareError = require('./middleware/error')
+  , querystring = require('querystring').parse
   , url = require('url').parse
   , fuse = require('fusing');
 
@@ -130,7 +131,7 @@ Transformer.readable('forEach', function forEach(type, req, res, next) {
     }
 
     layer.fn.call(primus, req, res, function done(err) {
-      if (err) return next(err);
+      if (err) return middlewareError(err, req, res);
 
       iterate(index);
     });


### PR DESCRIPTION
When a middleware fails we shouldn't pass the request to the underlying realtime framework.
It means that something went wrong and all the successive middleware in the stack are skipped.

When this happens i think that it makes sense to handle the request in the same way we handle the authorization. A connection should not be established.

As for the authorization if the `timeout` strategy in enabled a reconnection will be attempted every time a middleware fails.
