### PR TITLE
Return `true` when a sync middleware answers the request

### DIFF
--- a/middleware/primus.js
+++ b/middleware/primus.js
@@ -35,7 +35,7 @@ module.exports = function configure() {
     res.setHeader('Content-Length', length);
     res.end(library);
 
-    return false;
+    return true;
   }
 
   //

--- a/middleware/spec.js
+++ b/middleware/spec.js
@@ -24,7 +24,7 @@ module.exports = function configure() {
     res.setHeader('Content-Type', 'application/json');
     res.end(JSON.stringify(primus.spec));
 
-    return false;
+    return true;
   }
 
   //

--- a/transformer.js
+++ b/transformer.js
@@ -120,7 +120,7 @@ Transformer.readable('forEach', function forEach(type, req, res, next) {
     if (!layer.enabled || layer.fn[type] === false) return iterate(index);
 
     if (layer.length === 2) {
-      if (layer.fn.call(primus, req, res) === false) return;
+      if (layer.fn.call(primus, req, res)) return;
       return iterate(index);
     }
 


### PR DESCRIPTION
When a synchronous middleware answers the request return `true` instead of `false`.
I Think it's more intuitive and it's consistent with the `access-control` middleware.
