### PR TITLE
Improve the reliability of the port number extraction when `url.port` is undefined

### DIFF
--- a/primus.js
+++ b/primus.js
@@ -413,11 +413,15 @@ try {
     // and guess at a value from the 'href' value
     //
     if (!data.port) {
-      if (!data.href) data.href = '';
-      if ((data.href.match(/\:/g) || []).length > 1) {
-        data.port = data.href.split(':')[2].split('/')[0];
-      } else {
-        data.port = ('https' === data.href.substr(0, 5)) ? 443 : 80;
+      var splits = (data.href || '').split('/');
+      if (splits.length > 2) {
+        var host = splits[2]
+          , atSignIndex = host.lastIndexOf('@');
+
+        if (~atSignIndex) host = host.slice(atSignIndex + 1);
+
+        splits = host.split(':');
+        if (splits.length === 2) data.port = splits[1];
       }
     }
 


### PR DESCRIPTION
This slightly improves the port number extraction to make it work when more complex URLs are used.
The default ports are already correctly handled in the `primus.uri` method.
