### PR TITLE
Disable the query string when connecting to a Unix domain socket

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -43,7 +43,7 @@ exports.create = function create(transformer, fn, port) {
     } else {
       pathname = port;
       port = exports.port;
-      pathname = String(path.join(pathname, String(port)));
+      pathname = path.join(pathname, port + '');
     }
     if (fs.existsSync(pathname)) {
       fs.unlinkSync(pathname);
@@ -108,11 +108,11 @@ exports.create = function create(transformer, fn, port) {
   if (pathname) {
     server.make_addr = function (auth, query) {
       return 'ws+unix://' + (auth ? auth + '@' : '') + pathname;
-    }
+    };
   } else {
     server.make_addr = function (auth, query) {
       return 'http://' + (auth ? auth + '@' : '') + 'localhost:' + port + (query ? '/' + query : '');
-    }
+    };
   }
 
   server.addr = server.make_addr();

--- a/transformers/websockets/client.js
+++ b/transformers/websockets/client.js
@@ -41,19 +41,21 @@ module.exports = function client() {
     // Primus when we connect.
     //
     try {
+      var prot = primus.url.protocol === 'ws+unix:' ? 'ws+unix' : 'ws'
+        , qsa = prot === 'ws';
+
       //
       // Only allow primus.transport object in Node.js, it will throw in
       // browsers with a TypeError if we supply to much arguments.
       //
-      var prot = primus.url.protocol === 'ws+unix:' ? 'ws+unix' : 'ws';
       if (Factory.length === 3) {
         primus.socket = socket = new Factory(
-          primus.uri({ protocol: prot, query: true }),  // URL
+          primus.uri({ protocol: prot, query: qsa }),   // URL
           [],                                           // Sub protocols
           primus.transport                              // options.
         );
       } else {
-        primus.socket = socket = new Factory(primus.uri({ protocol: prot, query: true }));
+        primus.socket = socket = new Factory(primus.uri({ protocol: prot, query: qsa }));
       }
     } catch (e) { return primus.emit('error', e); }
 


### PR DESCRIPTION
The cache buster parameter used to prevent back forward cache broke `ws+unix`.
This disable the query string when `ws+unix` is used.
