### PR TITLE
Add ability to use `primus.forEach` asynchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -919,6 +919,23 @@ primus.forEach(function (spark, id, connections) {
 });
 ```
 
+The method can be also used asynchronously. To enable the asynchronous iteration
+you have to call `Primus#forEach` with two arguments. The first is the iterator
+function that is called on every step. The iterator is called with a connection
+from the list and a callback for when it has finished. The second argument is
+the main callback and is called when the iteration has finished.
+
+```js
+primus.forEach(function (spark, next) {
+  //
+  // Do something and call next when done
+  //
+  next();
+}, function (err) {
+  console.log('We are done');
+});
+```
+
 ### Destruction
 
 In rare cases you might need to destroy the Primus instance you've created. You

--- a/test/primus.test.js
+++ b/test/primus.test.js
@@ -345,6 +345,37 @@ describe('Primus', function () {
         done();
       });
     });
+
+    it('iterates over all active connections asynchronously', function (done) {
+      var iterations = 4
+        , interval;
+
+      while (iterations) {
+        iterations--;
+        new primus.Spark();
+      }
+
+      process.nextTick(function () {
+        expect(primus.connected).to.equal(4);
+
+        //
+        // Simulate new incoming connections while we iterate.
+        //
+        interval = setInterval(function () {
+          new primus.Spark();
+        }, 4);
+
+        primus.forEach(function (spark, next) {
+          iterations++;
+          expect(spark).to.be.instanceOf(primus.Spark);
+          setTimeout(next, 2);
+        }, function () {
+          expect(iterations).to.equal(7);
+          clearInterval(interval);
+          done();
+        });
+      });
+    });
   });
 
   describe('#library', function () {


### PR DESCRIPTION
I can't find a real use case for this at the moment. I would prefer to fix the `destroy` "issue" by removing `nextTick` in the `spark.end` method. But if there was really a reson for the `nextTick` we can revert the change and use this method instead.

It can also be useful in future, who knows.
