### PR TITLE
Emit the `connection` event before the `data` event

### DIFF
--- a/spark.js
+++ b/spark.js
@@ -275,7 +275,7 @@ Spark.readable('__initialise', [function initialise() {
   // Announce a new connection. This allows the transformers to change or listen
   // to events before we announce it.
   //
-  (global.setImmediate || process.nextTick)(function tick() {
+  process.nextTick(function tick() {
     primus.emit('connection', spark);
   });
 }]);

--- a/test/common.js
+++ b/test/common.js
@@ -1,10 +1,12 @@
 'use strict';
 
-var chai = require('chai');
-chai.config.includeStack = true;
+var chai = require('chai')
+  , http = require('http')
+  , path = require('path')
+  , fs = require('fs');
 
-var path = require('path');
-var fs = require('fs');
+chai.config.includeStack = true;
+http.globalAgent.maxSockets = 15;
 
 //
 // Expose primus
@@ -52,7 +54,7 @@ exports.create = function create(transformer, fn, port) {
     port = port || exports.port;
   }
 
-  var server = require('http').createServer(function handle(req, res) {
+  var server = http.createServer(function handle(req, res) {
     console.error('');
     console.error('Uncaught request', req.url);
     console.error('');

--- a/test/primus.test.js
+++ b/test/primus.test.js
@@ -113,7 +113,7 @@ describe('Primus', function () {
 
         done();
       }, 0);
-    }, 0);
+    });
   });
 
   it('serves the primus client on /primus/primus.js', function (done) {

--- a/test/spark.test.js
+++ b/test/spark.test.js
@@ -22,13 +22,13 @@ describe('Spark', function () {
     catch (e) { done(); }
   });
 
-  it('creates a id if none is supplied', function () {
+  it('creates an id if none is supplied', function () {
     var spark = new primus.Spark();
 
     expect(spark.id).to.be.a('string');
   });
 
-  it('is an Stream instance', function () {
+  it('is a Stream instance', function () {
     expect(new primus.Spark()).to.be.instanceOf(require('stream'));
   });
 

--- a/test/transformer.base.js
+++ b/test/transformer.base.js
@@ -864,6 +864,23 @@ module.exports = function base(transformer, pathname, transformer_name) {
     });
 
     describe('Server', function () {
+      it('emits a `connection` event before any `data` event', function (done) {
+        var create = 10
+          , foo = 0;
+
+        primus.on('connection', function (spark) {
+          spark.on('data', function (data) {
+            if ('foo' === data) {
+              if (++foo === create) done();
+            }
+          });
+        });
+
+        for (var i = 0; i < create; i++) {
+          (new Socket(server.addr)).write('foo');
+        }
+      });
+
       it('emits `end` when the connection is closed', function (done) {
         primus.on('connection', function (spark) {
           spark.on('end', done);


### PR DESCRIPTION
When using `setImmediate`, there are cases where the `data` event on the spark is called before the `connection` event on the primus instance:

``` js
primus.on('connection', function (spark) {
  console.log(spark.id + ' connected');
  spark.on('data', function (data) {
    console.log(data);
  });
});

for (var i = 0; i < 10; i++) {
  (new primus.Socket(url)).write('hello ' + i);
}
```

This causes the loss of some messages because we add the listener for `data` after the `connection`, so i think it's better to only use `process.nextTick`.

**The integration test included with the patch does not pass with the `browserchannel` transformer. All the connection are created but the message is received only for the first four. This needs investigation.**

**Update**: the test wasn't passing because by default the maximum concurrent sockets that the http agent can have open per origin are 5.
This number has been increased to 15 using `http.globalAgent.maxSockets = 15;`. 
