### PR TITLE
Emit error event for close event codes above 1000.

### DIFF
--- a/transformers/sockjs/client.js
+++ b/transformers/sockjs/client.js
@@ -48,7 +48,7 @@ module.exports = function client() {
     socket.onopen = primus.emits('open');
     socket.onerror = primus.emits('error');
     socket.onclose = function (e) {
-      var event = e && e.code === 1002 ? 'error' : 'end';
+      var event = e && e.code > 1000 ? 'error' : 'end';
 
       //
       // The timeout replicates the behaviour of primus.emits so we're not


### PR DESCRIPTION
Pertains to issues #75 and #32. Without this change, SockJS reconnection was failing because the "error" event was not emitted for "close" events that were not clean such as "All Transports Failed" (code 2000). This changes the check for codes above 1000 which should all be errors.
