### PR TITLE
Stop the reconnection procedure when `primus.end` is called

### DIFF
--- a/test/transformer.base.js
+++ b/test/transformer.base.js
@@ -421,6 +421,22 @@ module.exports = function base(transformer, pathname, transformer_name) {
         socket.on('end', done);
       });
 
+      it('should allow to stop the reconnection procedure', function (done) {
+        primus.on('connection', function (spark) {
+          spark.end(null, { reconnect: true });
+        });
+
+        var socket = new Socket(server.addr);
+
+        socket.on('reconnecting', socket.end);
+
+        socket.on('reconnect', function (message) {
+          throw new Error('bad');
+        });
+
+        socket.on('end', done);
+      });
+
       it('should allow access to the original HTTP request', function (done) {
         primus.on('connection', function (spark) {
           expect(spark.request).to.not.equal(undefined);


### PR DESCRIPTION
When the connection is opened manually it could be useful to have a way to stop the reconnection without disabling it completely.
For example before calling `primus.open()`, a developer could use `primus.end()` to ensure that the connection is closed and primus isn't trying or planning to reconnect.
This patches `primus.end()` to make it possible.
