### PR TITLE
[minor] Add connection timeout to spec

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,8 @@ function Primus(server, options) {
   //
   this.spec = {
     version: this.version,
-    pathname: this.pathname
+    pathname: this.pathname,
+    timeout: this.timeout
   };
 
   //

--- a/test/transformer.base.js
+++ b/test/transformer.base.js
@@ -1217,6 +1217,7 @@ module.exports = function base(transformer, pathname, transformer_name) {
             expect(body.version).to.equal(primus.version);
             expect(body.pathname).to.equal('/primus');
             expect(body.parser).to.equal('json');
+            expect(body.timeout).to.equal(35000);
             done();
           }
         );


### PR DESCRIPTION
This PR is related to the connection timeout issue discussed in #175.

In the javascript _Primus_ implementation, the client-side timeout is always correct since the client library is generated by the server application. However, in the _Objective-C_ implementation there is no way to know what this timeout is.

In short, the _Objective-C_ implementation needs to set a sensible client-side timeout (_less than or equal to_ the timeout defined on the server-side) to avoid being killed by the server.

I've exposed the timeout value on the `spec` endpoint and modified the respective tests.
