### PR TITLE
[Sockjs] Handle 1006 error as 'end' event rather than 'error'

### DIFF
--- a/transformers/sockjs/client.js
+++ b/transformers/sockjs/client.js
@@ -48,7 +48,7 @@ module.exports = function client() {
     socket.onopen = primus.emits('open');
     socket.onerror = primus.emits('error');
     socket.onclose = function (e) {
-      var event = e && e.code > 1000 ? 'error' : 'end';
+      var event = e && e.code > 1000 && e.code !== 1006 ? 'error' : 'end';
 
       //
       // The timeout replicates the behaviour of primus.emits so we're not


### PR DESCRIPTION
When a Websocket connection is suddenly interrupted by a server crash or shutdown, Primus generates an 'error' event rather than a 'close' event. This leaves the Spark in an open state for while, and therefore does not trigger the reconnection algorithm.
SockJS seems outputting this error:
{type: 'close', code: '1006', reason: 'Websocket connection broken'}
This patch treats 1006 errors as an 'end' event, thus fixing the issue.
