### PR TITLE
Remove some unneeded conditional statements

### DIFF
--- a/transformer.js
+++ b/transformer.js
@@ -102,8 +102,7 @@ Transformer.readable('forEach', function forEach(type, req, res, next) {
     , layers = transformer.primus.layers
     , primus = transformer.primus;
 
-  req.uri = req.uri || url(req.url, true);
-  req.query = req.query || req.uri.query || {};
+  req.query = req.uri.query || {};
 
   //
   // Add some silly HTTP properties for connect.js compatibility.


### PR DESCRIPTION
If i'm not wrong `req.uri` is always set when we test if the request should be captured by primus.
`req.query` should be `undefined` since we are the first to capture the request, so get it directly from `req.uri`.
