### PR TITLE
Treat protocol-level pings as valid pings with `ws` transport.

### DIFF
--- a/transformers/websockets/server.js
+++ b/transformers/websockets/server.js
@@ -53,6 +53,8 @@ module.exports = function server() {
         socket.send(data, { binary: true }, noop);
       });
 
+      // 'ws' supports protocol-level ping. Reset the heartbeat.
+      socket.on('ping', spark.heartbeat.bind(spark));
       socket.on('message', spark.emits('data'));
       socket.on('error', spark.emits('error'));
       socket.on('close', spark.emits('end', function parser() {


### PR DESCRIPTION
`ws` fires a `ping` event when the `ping` control frame comes through, and automatically sends a `pong` back. However, this didn't update Primus' internal heartbeat timer, so clients who are pinging healthily will still be disconnected if they are not sending data. Many modern external websocket clients support protocol-level ping and automatically send frames at intervals. This is a nice pattern and it would be great to support it without requesting that users of external tools send `primus::ping::<timestamp>` messages, or some other bogus message to reset the counter.

This PR simply listens for the [ping event](https://github.com/einaros/ws/blob/7bdaee4c7ee82aa8a8ea19e9b5b8dcb230312964/doc/ws.md#event-ping), and resets the heartbeat timer.
