### PR TITLE
Defer all `incoming::` prefixed events except `incoming::pong`

### DIFF
--- a/primus.js
+++ b/primus.js
@@ -350,15 +350,32 @@ Primus.prototype.ark = {};
 
 /**
  * Simple emit wrapper that returns a function that emits an event once it's
- * called. This makes it easier for transports to emit specific events. The
- * scope of this function is limited as it will only emit one single argument.
+ * called. This makes it easier for transports to emit specific events.
  *
- * @param {String} event Name of the event that we should emit.
- * @param {Function} parser Argument parser.
- * @returns {Function} The wrapped function that will emit events when called.
- * @public
+ * @returns {Function} A function that will emit the event when called.
+ * @api public
  */
 Primus.prototype.emits = require('emits');
+
+/**
+ * A small wrapper around `emits` to add a default parser when one is not
+ * supplied. The default parser will defer the emission of the event to make
+ * sure that the event is emitted at the correct time.
+ *
+ * @returns {Function} A function that will emit the event when called.
+ * @api private
+ */
+Primus.prototype.trigger = function trigger() {
+  for (var i = 0, l = arguments.length, args = new Array(l); i < l; i++) {
+    args[i] = arguments[i];
+  }
+
+  if ('function' !== typeof args[l - 1]) args.push(function defer(next) {
+    setTimeout(next, 0);
+  });
+
+  return this.emits.apply(this, args);
+};
 
 /**
  * Return the given plugin.

--- a/transformers/browserchannel/client.js
+++ b/transformers/browserchannel/client.js
@@ -48,10 +48,10 @@ module.exports = function client() {
     //
     // Setup the Event handlers.
     //
-    socket.onopen = primus.emits('incoming::open');
-    socket.onerror = primus.emits('incoming::error');
-    socket.onclose = primus.emits('incoming::end');
-    socket.onmessage = primus.emits('incoming::data', function parse(next, evt) {
+    socket.onopen = primus.trigger('incoming::open');
+    socket.onerror = primus.trigger('incoming::error');
+    socket.onclose = primus.trigger('incoming::end');
+    socket.onmessage = primus.trigger('incoming::data', function parse(next, evt) {
       setTimeout(function defer() {
         next(undefined, evt.data);
       }, 0);

--- a/transformers/engine.io/client.js
+++ b/transformers/engine.io/client.js
@@ -9,14 +9,10 @@
  * @api private
  */
 module.exports = function client() {
-  var onmessage = this.emits('incoming::data', function parse(next) {
-      setTimeout(function defer() {
-        next();
-      }, 0);
-    })
-    , onerror = this.emits('incoming::error')
-    , onopen = this.emits('incoming::open')
-    , onclose = this.emits('incoming::end')
+  var onmessage = this.trigger('incoming::data')
+    , onerror = this.trigger('incoming::error')
+    , onopen = this.trigger('incoming::open')
+    , onclose = this.trigger('incoming::end')
     , primus = this
     , socket;
 

--- a/transformers/faye/client.js
+++ b/transformers/faye/client.js
@@ -66,10 +66,10 @@ module.exports = function client() {
     // Setup the Event handlers.
     //
     socket.binaryType = 'arraybuffer';
-    socket.onopen = primus.emits('incoming::open');
-    socket.onerror = primus.emits('incoming::error');
-    socket.onclose = primus.emits('incoming::end');
-    socket.onmessage = primus.emits('incoming::data', function parse(next, evt) {
+    socket.onopen = primus.trigger('incoming::open');
+    socket.onerror = primus.trigger('incoming::error');
+    socket.onclose = primus.trigger('incoming::end');
+    socket.onmessage = primus.trigger('incoming::data', function parse(next, evt) {
       setTimeout(function defer() {
         next(undefined, evt.data);
       }, 0);

--- a/transformers/socket.io/client.js
+++ b/transformers/socket.io/client.js
@@ -9,14 +9,10 @@
  * @api private
  */
 module.exports = function client() {
-  var ondisconnect = this.emits('incoming::end')
-    , onconnect = this.emits('incoming::open')
-    , onmessage = this.emits('incoming::data', function parse(next) {
-        setTimeout(function defer() {
-          next();
-        }, 0);
-      })
-    , onerror = this.emits('incoming::error')
+  var ondisconnect = this.trigger('incoming::end')
+    , onconnect = this.trigger('incoming::open')
+    , onmessage = this.trigger('incoming::data')
+    , onerror = this.trigger('incoming::error')
     , primus = this
     , socket;
 

--- a/transformers/sockjs/client.js
+++ b/transformers/sockjs/client.js
@@ -48,11 +48,11 @@ module.exports = function client() {
     //
     // Setup the Event handlers.
     //
-    socket.onopen = primus.emits('incoming::open');
-    socket.onerror = primus.emits('incoming::error');
+    socket.onopen = primus.trigger('incoming::open');
+    socket.onerror = primus.trigger('incoming::error');
     socket.onclose = function (e) {
       //
-      // The timeout replicates the behaviour of primus.emits so we're not
+      // The timeout replicates the behaviour of primus.trigger so we're not
       // affected by any timing bugs.
       //
       setTimeout(function timeout() {
@@ -60,7 +60,7 @@ module.exports = function client() {
         primus.emit('incoming::end');
       }, 0);
     };
-    socket.onmessage = primus.emits('incoming::data', function parse(next, evt) {
+    socket.onmessage = primus.trigger('incoming::data', function parse(next, evt) {
       setTimeout(function defer() {
         next(undefined, evt.data);
       }, 0);

--- a/transformers/websockets/client.js
+++ b/transformers/websockets/client.js
@@ -68,10 +68,10 @@ module.exports = function client() {
     // Setup the Event handlers.
     //
     socket.binaryType = 'arraybuffer';
-    socket.onopen = primus.emits('incoming::open');
-    socket.onerror = primus.emits('incoming::error');
-    socket.onclose = primus.emits('incoming::end');
-    socket.onmessage = primus.emits('incoming::data', function parse(next, evt) {
+    socket.onopen = primus.trigger('incoming::open');
+    socket.onerror = primus.trigger('incoming::error');
+    socket.onclose = primus.trigger('incoming::end');
+    socket.onmessage = primus.trigger('incoming::data', function parse(next, evt) {
       setTimeout(function defer() {
         next(undefined, evt.data);
       }, 0);


### PR DESCRIPTION
Not really happy with this, but it was the cleanest solution I could come up with.