### PR TITLE
Fix undefined Event.prototype.hasOwnProperty issue.

### DIFF
--- a/primus.js
+++ b/primus.js
@@ -540,7 +540,8 @@ Primus.prototype.initialise = function initialise(options) {
       //
       err = new Error(e.message || e.reason);
       for (var key in e) {
-        if (e.hasOwnProperty(key)) err[key] = e[key];
+        if (Object.prototype.hasOwnProperty.call(e, key))
+          err[key] = e[key];
       }
     }
     //


### PR DESCRIPTION
For some reason in Firefox 31.4.0
window.Event.prototype.hasOwnProperty === undefined.

This causes an error in primus.on('incoming::error', ...)
and hence missing 'error' event.