### PR TITLE
Refactor the way we handle custom export names

### DIFF
--- a/test/primus.test.js
+++ b/test/primus.test.js
@@ -633,14 +633,14 @@ describe('Primus', function () {
 
       primus.save(sync);
       expect(fs.readFileSync(sync, 'utf-8')).to.equal(primus.library());
-      expect(fs.readFileSync(sync, 'utf-8').match(/(?:^|[^"])Unicron(?!")/g)).length
+      expect(fs.readFileSync(sync, 'utf-8').match(/"Unicron"/g)).length
           .to.be.greaterThan(0);
 
       primus.save(async, function (error) {
         if (error) return done(error);
 
         expect(fs.readFileSync(async, 'utf-8')).to.equal(primus.library());
-        expect(fs.readFileSync(async, 'utf-8').match(/(?:^|[^"])Unicron(?!")/g)).length
+        expect(fs.readFileSync(async, 'utf-8').match(/"Unicron"/g)).length
           .to.be.greaterThan(0);
         done();
       });


### PR DESCRIPTION
Renaming all `Primus` identifiers is no longer required.

This also fixes an issue in the closure introduced [here](https://github.com/primus/primus/pull/356). If I'm not wrong the `Primus` identifiers were not renamed [here](https://github.com/primus/primus/blob/76c4e8d292b70c8a06871a002375f17af823d0a4/index.js#L606), so it was probably broken when using a custom class name.