### PR TITLE
Add a 'heartbeat' event.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1089,6 +1089,7 @@ Event                 | Usage       | Location      | Description
 `outgoing::ping`      | private     | client        | We're sending a ping message.
 `incoming::pong`      | private     | client        | We received a pong message.
 `outgoing::pong`      | private     | spark         | We're sending a pong message.
+`heartbeat`           | **public**  | spark         | We've received a heartbeat and have reset the timer.
 `online`              | **public**  | client        | We've regained a network connection.
 `offline`             | **public**  | client        | We've lost our internet connection.
 `log`                 | **public**  | server        | Log messages.

--- a/spark.js
+++ b/spark.js
@@ -118,6 +118,9 @@ Spark.readable('heartbeat', function heartbeat() {
     spark.end(undefined, { reconnect: true });
   }, spark.primus.timeout);
 
+  // Emit an event so the application can know the timer has been reset.
+  spark.emit('heartbeat');
+
   return this;
 });
 

--- a/test/spark.test.js
+++ b/test/spark.test.js
@@ -283,4 +283,40 @@ describe('Spark', function () {
       Spark.prototype.__initialise.length = 1;
     });
   });
+
+  describe('ping/pong', function () {
+    it('writes primus::pong on a ping event', function (done) {
+      var spark = new primus.Spark(),
+        d = Date.now();
+
+      spark.on('outgoing::data', function onData(data) {
+        expect(data).to.equal('"primus::pong::' + d + '"');
+        spark.removeListener('outgoing::data', onData);
+        done();
+      });
+
+      spark.emit('incoming::ping', d);
+    });
+
+    it('emits outgoing::pong on a ping event', function (done) {
+      var spark = new primus.Spark();
+
+      spark.on('outgoing::pong', done);
+      spark.emit('incoming::ping');
+    });
+
+    it('emits "heartbeat" when heartbeat is called directly', function (done) {
+      var spark = new primus.Spark();
+
+      spark.on('heartbeat', done);
+      spark.heartbeat();
+    });
+
+    it('emits "heartbeat" when data is received', function (done) {
+      var spark = new primus.Spark();
+
+      spark.on('heartbeat', done);
+      spark.emit('incoming::data', 'data');
+    });
+  });
 });


### PR DESCRIPTION
This fires every time the internal timeout timer is reset.

Due to #323 and anticipated further support for protocol-level ping/pong, this
can be useful as a catch-all for both types of heartbeats: 'primus::ping' and
the 'ping' control frame.

This can be useful for services that might want to know if a connection is
alive, whether the activity is a `ping` control frame or a message.

I found this useful in an application where I wanted to allow users to opt in
to heartbeating. Since it is not possible to set a heartbeat timeout per-spark,
one can simply wait for this event and cancel the timeout (`conn.timeout`).

Alternatively, for my use case, the `primus.timeout` property could be copied
to each spark as `spark.timeoutInterval` so it could be overridden by the
application, but I thought that this event was perhaps more useful.

Thoughts?