### PR TITLE
Tweak our `incoming::ping` listener to handle WebSocket pings

### DIFF
--- a/spark.js
+++ b/spark.js
@@ -215,9 +215,14 @@ Spark.readable('__initialise', [function initialise() {
   });
 
   //
-  // We've received a ping message.
+  // We've received a ping event. This is fired upon receipt of a WebSocket
+  // Ping frame or a `pimus::ping::<timestamp>` message. In the former case
+  // the listener is called without arguments and we should only reset the
+  // heartbeat.
   //
   ultron.on('incoming::ping', function ping(time) {
+    if (time === undefined) return spark.heartbeat();
+
     spark.emit('outgoing::pong', time);
     spark._write('primus::pong::'+ time);
   });

--- a/transformers/websockets/server.js
+++ b/transformers/websockets/server.js
@@ -53,11 +53,12 @@ module.exports = function server() {
         socket.send(data, { binary: true }, noop);
       });
 
-      // 'ws' supports protocol-level ping. Reset the heartbeat.
-      socket.on('ping', spark.heartbeat.bind(spark));
       socket.on('message', spark.emits('incoming::data'));
       socket.on('error', spark.emits('incoming::error'));
-      socket.on('close', spark.emits('incoming::end', function parser(next) {
+      socket.on('ping', spark.emits('incoming::ping', function strip(next) {
+        next(undefined, null);
+      }));
+      socket.on('close', spark.emits('incoming::end', function clear(next) {
         socket.removeAllListeners();
         socket = null;
         next();


### PR DESCRIPTION
We first check if a timestamp has been sent with the event.
If we don't have a timestamp, we assume that the event has been fired by a WebSocket ping and only reset the spark heartbeat.