### PR TITLE
Simplify `primus.uri` by taking advantage of `url-parse`

### DIFF
--- a/primus.js
+++ b/primus.js
@@ -1079,7 +1079,7 @@ Primus.prototype.uri = function uri(options) {
   options = options || {};
   options.protocol = 'protocol' in options
     ? options.protocol
-    : 'http';
+    : 'http:';
   options.query = url.query && qsa
     ? url.query.slice(1)
     : false;
@@ -1095,26 +1095,15 @@ Primus.prototype.uri = function uri(options) {
       : false;
   options.pathname = 'pathname' in options
     ? options.pathname
-    : this.pathname.slice(1);
+    : this.pathname;
   options.port = 'port' in options
     ? +options.port
     : +url.port || (options.secure ? 443 : 80);
-  options.host = 'host' in options
-    ? options.host
-    : url.hostname || url.host.replace(':'+ url.port, '');
 
   //
   // Allow transformation of the options before we construct a full URL from it.
   //
   this.emit('outgoing::url', options);
-
-  //
-  // `url.host` might be undefined (e.g. when using zombie) so we use the
-  // hostname and port defined above.
-  //
-  var host = (443 !== options.port && 80 !== options.port)
-    ? options.host +':'+ options.port
-    : options.host;
 
   //
   // We need to make sure that we create a unique connection URL every time to
@@ -1126,19 +1115,18 @@ Primus.prototype.uri = function uri(options) {
   options.query = this.querystringify(querystring);
 
   //
-  // Automatically suffix the protocol so we can supply `ws` and `http` and it gets
-  // transformed correctly.
+  // Automatically suffix the protocol so we can supply `ws:` and `http:` and
+  // it gets transformed correctly.
   //
-  server.push(options.secure ? options.protocol +'s:' : options.protocol +':', '');
+  server.push(options.secure ? options.protocol.replace(':', 's:') : options.protocol, '');
 
-  if (options.auth) server.push(options.auth +'@'+ host);
-  else server.push(host);
+  server.push(options.auth ? options.auth +'@'+ url.host : url.host);
 
   //
   // Pathnames are optional as some Transformers would just use the pathname
   // directly.
   //
-  if (options.pathname) server.push(options.pathname);
+  if (options.pathname) server.push(options.pathname.slice(1));
 
   //
   // Optionally add a search query.

--- a/transformers/browserchannel/client.js
+++ b/transformers/browserchannel/client.js
@@ -35,13 +35,10 @@ module.exports = function client() {
   primus.on('outgoing::open', function connect() {
     primus.emit('outgoing::end');
 
-    var url = primus.uri({ protocol: 'http' });
+    var url = primus.uri({ protocol: 'http:' });
 
     primus.socket = socket = new Factory(url, primus.merge(primus.transport, {
-      extraParams: primus.querystring(primus.uri({
-        protocol: 'http',
-        query: true
-      }).replace(url, '')),
+      extraParams: primus.querystring(primus.url.query),
       reconnect: false
     }));
 

--- a/transformers/engine.io/client.js
+++ b/transformers/engine.io/client.js
@@ -41,7 +41,7 @@ module.exports = function client() {
 
     primus.socket = socket = factory(primus.merge(primus.transport,
       primus.url,
-      primus.uri({ protocol: 'http', query: true, object: true }), {
+      primus.uri({ protocol: 'http:', query: true, object: true }), {
       //
       // Never remember upgrades as switching from a WIFI to a 3G connection
       // could still get your connection blocked as 3G connections are usually

--- a/transformers/faye/client.js
+++ b/transformers/faye/client.js
@@ -50,13 +50,13 @@ module.exports = function client() {
       //
       if (Factory.length === 3) {
         primus.socket = socket = new Factory(
-          primus.uri({ protocol: 'ws', query: true }),  // URL
+          primus.uri({ protocol: 'ws:', query: true }),  // URL
           [],                                           // Sub protocols
           primus.transport                              // options.
         );
       } else {
         primus.socket = socket = new Factory(primus.uri({
-          protocol: 'ws',
+          protocol: 'ws:',
           query: true
         }));
       }

--- a/transformers/socket.io/client.js
+++ b/transformers/socket.io/client.js
@@ -54,16 +54,16 @@ module.exports = function client() {
     // We need to directly use the parsed URL details here to generate the
     // correct urls for Socket.IO to use.
     //
-    primus.socket = socket = (new Socket(primus.merge({},
-      primus.url,
-      primus.uri({ protocol: 'http', query: true, object: true }),
-      primus.merge(primus.transport, {
+    primus.socket = socket = (new Socket(primus.merge(primus.transport,
+      primus.url, {
+        host: primus.url.hostname
+      }, primus.uri({ protocol: 'http:', query: true, object: true }), {
       'resource': primus.pathname.slice(1),
       'force new connection': true,
       'flash policy port': 843,
       'transports': transports,
       'reconnect': false
-    })))).of(''); // Force namespace
+    }))).of(''); // Force namespace
 
     //
     // Setup the Event handlers.

--- a/transformers/sockjs/client.js
+++ b/transformers/sockjs/client.js
@@ -36,7 +36,7 @@ module.exports = function client() {
     primus.emit('outgoing::end');
 
     primus.socket = socket = new Factory(
-      primus.uri({ protocol: 'http', query: true }),
+      primus.uri({ protocol: 'http:', query: true }),
       null,
       primus.merge(primus.transport, {
       info: {

--- a/transformers/websockets/client.js
+++ b/transformers/websockets/client.js
@@ -43,8 +43,8 @@ module.exports = function client() {
     // Primus when we connect.
     //
     try {
-      var prot = primus.url.protocol === 'ws+unix:' ? 'ws+unix' : 'ws'
-        , qsa = prot === 'ws';
+      var prot = primus.url.protocol === 'ws+unix:' ? 'ws+unix:' : 'ws:'
+        , qsa = prot === 'ws:';
 
       //
       // Only allow primus.transport object in Node.js, it will throw in


### PR DESCRIPTION
This patch slightly simplifies the `primus.uri` method by removing no longer needed code thanks to `url-parse`.

This also slightly changes the values of the `protocol` and `pathname` properties to make them a little more consistent with the `URLUtils` interface.