### PR TITLE
Set the `ping` option to `false` when the heartbeats are disabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -543,10 +543,15 @@ Primus.readable('library', function compile(nodejs) {
   // `ping` interval of the client to ensure that we've sent the server
   // a message before the timeout gets triggered and we get disconnected.
   //
-  if ('number' === typeof this.timeout) {
-    var timeout = this.timeout - 10000;
-    log('adding a custom timeout to the client');
-    client = client.replace('options.ping : 25e3;', 'options.ping : '+ timeout +';');
+  if (this.timeout) {
+    log('updating the default value of the client `ping` option');
+    client = client.replace(
+      'options.ping : 25e3;',
+      'options.ping : '+ (this.timeout - 10000) +';'
+    );
+  } else {
+    log('setting the default value of the client `ping` option to `false`');
+    client = client.replace('options.ping : 25e3;', 'options.ping : false;');
   }
 
   //

--- a/spark.js
+++ b/spark.js
@@ -106,7 +106,7 @@ Spark.readable('heartbeat', function heartbeat() {
 
   clearTimeout(spark.timeout);
 
-  if ('number' !== typeof spark.primus.timeout) return spark;
+  if (!spark.primus.timeout) return spark;
 
   log('setting new heartbeat timeout for %s', spark.id);
 

--- a/test/primus.test.js
+++ b/test/primus.test.js
@@ -551,17 +551,21 @@ describe('Primus', function () {
       expect(library).to.include('i am a client plugin');
     });
 
-    it('updates the default timeout', function (done) {
+    it('updates the default value of the `ping` option', function (done) {
       var primus = new Primus(server, { timeout: 60000 })
-        , Socket = primus.Socket;
-
-      var socket = new Socket('http://localhost:'+ server.portnumber);
+        , socket = new primus.Socket('http://localhost:'+ server.portnumber);
 
       expect(socket.options.ping).to.equal(50000);
-      socket.on('open', socket.end).on('end', done);
+      socket.on('open', socket.end).on('end', function () {
+        primus = new Primus(server, { timeout: false });
+        socket = primus.Socket('http://localhost:'+ server.portnumber);
+
+        expect(socket.options.ping).to.equal(false);
+        socket.on('open', socket.end).on('end', done);
+      });
     });
 
-    it('still allows overriding the default timeout', function (done) {
+    it('still allows overriding the value of the `ping` option', function (done) {
       var primus = new Primus(server, { timeout: 60000 })
         , Socket = primus.Socket;
 


### PR DESCRIPTION
By default the client sends the ping messages even when the heartbeat timeout is disabled.
To stop the client from sending these messages it is necessary to manually set the `ping` option to `false`.

With this patch the default value of the `ping` option is automatically set to `false` when the heartbeats are disabled.