### PR TITLE
Stop deferring the events on the client

### DIFF
--- a/primus.js
+++ b/primus.js
@@ -285,26 +285,6 @@ Primus.prototype.ark = {};
 Primus.prototype.emits = require('emits');
 
 /**
- * A small wrapper around `emits` to add a default parser when one is not
- * supplied. The default parser will defer the emission of the event to make
- * sure that the event is emitted at the correct time.
- *
- * @returns {Function} A function that will emit the event when called.
- * @api private
- */
-Primus.prototype.trigger = function trigger() {
-  for (var i = 0, l = arguments.length, args = new Array(l); i < l; i++) {
-    args[i] = arguments[i];
-  }
-
-  if ('function' !== typeof args[l - 1]) args.push(function defer(next) {
-    setTimeout(next, 0);
-  });
-
-  return this.emits.apply(this, args);
-};
-
-/**
  * Return the given plugin.
  *
  * @param {String} name The name of the plugin.

--- a/transformers/engine.io/client.js
+++ b/transformers/engine.io/client.js
@@ -9,10 +9,10 @@
  * @api private
  */
 module.exports = function client() {
-  var onmessage = this.trigger('incoming::data')
-    , onerror = this.trigger('incoming::error')
-    , onopen = this.trigger('incoming::open')
-    , onclose = this.trigger('incoming::end')
+  var onmessage = this.emits('incoming::data')
+    , onerror = this.emits('incoming::error')
+    , onopen = this.emits('incoming::open')
+    , onclose = this.emits('incoming::end')
     , primus = this
     , socket;
 

--- a/transformers/faye/client.js
+++ b/transformers/faye/client.js
@@ -66,13 +66,11 @@ module.exports = function client() {
     // Setup the Event handlers.
     //
     socket.binaryType = 'arraybuffer';
-    socket.onopen = primus.trigger('incoming::open');
-    socket.onerror = primus.trigger('incoming::error');
-    socket.onclose = primus.trigger('incoming::end');
-    socket.onmessage = primus.trigger('incoming::data', function parse(next, evt) {
-      setTimeout(function defer() {
-        next(undefined, evt.data);
-      }, 0);
+    socket.onopen = primus.emits('incoming::open');
+    socket.onerror = primus.emits('incoming::error');
+    socket.onclose = primus.emits('incoming::end');
+    socket.onmessage = primus.emits('incoming::data', function parse(next, evt) {
+      next(undefined, evt.data);
     });
   });
 

--- a/transformers/socket.io/client.js
+++ b/transformers/socket.io/client.js
@@ -9,10 +9,10 @@
  * @api private
  */
 module.exports = function client() {
-  var ondisconnect = this.trigger('incoming::end')
-    , onconnect = this.trigger('incoming::open')
-    , onmessage = this.trigger('incoming::data')
-    , onerror = this.trigger('incoming::error')
+  var ondisconnect = this.emits('incoming::end')
+    , onconnect = this.emits('incoming::open')
+    , onmessage = this.emits('incoming::data')
+    , onerror = this.emits('incoming::error')
     , primus = this
     , socket;
 

--- a/transformers/sockjs/client.js
+++ b/transformers/sockjs/client.js
@@ -48,22 +48,14 @@ module.exports = function client() {
     //
     // Setup the Event handlers.
     //
-    socket.onopen = primus.trigger('incoming::open');
-    socket.onerror = primus.trigger('incoming::error');
+    socket.onopen = primus.emits('incoming::open');
+    socket.onerror = primus.emits('incoming::error');
     socket.onclose = function (e) {
-      //
-      // The timeout replicates the behaviour of primus.trigger so we're not
-      // affected by any timing bugs.
-      //
-      setTimeout(function timeout() {
-        if (e && e.code > 1000) primus.emit('incoming::error', e);
-        primus.emit('incoming::end');
-      }, 0);
+      if (e && e.code > 1000) primus.emit('incoming::error', e);
+      primus.emit('incoming::end');
     };
-    socket.onmessage = primus.trigger('incoming::data', function parse(next, evt) {
-      setTimeout(function defer() {
-        next(undefined, evt.data);
-      }, 0);
+    socket.onmessage = primus.emits('incoming::data', function parse(next, evt) {
+      next(undefined, evt.data);
     });
   });
 

--- a/transformers/websockets/client.js
+++ b/transformers/websockets/client.js
@@ -68,13 +68,11 @@ module.exports = function client() {
     // Setup the Event handlers.
     //
     socket.binaryType = 'arraybuffer';
-    socket.onopen = primus.trigger('incoming::open');
-    socket.onerror = primus.trigger('incoming::error');
-    socket.onclose = primus.trigger('incoming::end');
-    socket.onmessage = primus.trigger('incoming::data', function parse(next, evt) {
-      setTimeout(function defer() {
-        next(undefined, evt.data);
-      }, 0);
+    socket.onopen = primus.emits('incoming::open');
+    socket.onerror = primus.emits('incoming::error');
+    socket.onclose = primus.emits('incoming::end');
+    socket.onmessage = primus.emits('incoming::data', function parse(next, evt) {
+      next(undefined, evt.data);
     });
   });
 


### PR DESCRIPTION
This is a breaking and maybe unwanted change.
It fixes some open issues (#320, #263, #264) and possible race conditions.

It removes a [workaround](https://gist.github.com/mloughran/2052006) used to prevent iOS 5 from crashing under certain circumstances.

In short it's a f**k you to the users of iOS 5, but I would give a stable and bug free library to the majority of the users rather than a buggy one to everyone.