### PR TITLE
Prevent the Spark prototype from being mutated

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,10 +78,14 @@ function Primus(server, options) {
 
   this.Spark.prototype = Object.create(Spark.prototype, {
     constructor: {
+      configurable: true,
       value: this.Spark,
-      writable: true,
-      enumerable: false,
-      configurable: true
+      writable: true
+    },
+    __initialise: {
+      value: Spark.prototype.__initialise.slice(),
+      configurable: true,
+      writable: true
     }
   });
 


### PR DESCRIPTION
#### The problem:

```js
'use strict';

const Primus = require('primus');
const http = require('http');

let primus = new Primus(http.createServer());

primus.use('bogus', {
  server : function srv(primus) {
    primus.Spark.prototype.initialise = function init() {};
  }
});

console.log(primus.Spark.prototype.__initialise);
// => [ [Function: initialise], [Function: init] ]

primus = new Primus(http.createServer());

console.log(primus.Spark.prototype.__initialise);
// => [ [Function: initialise], [Function: init] ]
```

The second instance does not use any plugins so the `__initialise` array
should not include the `init` function.

#### The fix:

Add an `__initialise` property in the `Sparky` prototype which is a copy
of the original `__initialise` array from the `Spark` prototype.