### PR TITLE
rename Primus.require => Primus.requires

### DIFF
--- a/primus.js
+++ b/primus.js
@@ -192,7 +192,7 @@ function Primus(url, options) {
  * @returns {Object|Undefined} The module that we required.
  * @api private
  */
-Primus.require = function requires(name) {
+Primus.requires = Primus.require = function requires(name) {
   if ('function' !== typeof require) return undefined;
 
   return !('function' === typeof define && define.amd)
@@ -207,7 +207,7 @@ Primus.require = function requires(name) {
 var Stream;
 
 try {
-  Primus.Stream = Stream = Primus.require('stream');
+  Primus.Stream = Stream = Primus.requires('stream');
 
   //
   // Normally inheritance is done in the same way as we do in our catch
@@ -217,7 +217,7 @@ try {
   //
   // @see https://github.com/joyent/node/issues/4971
   //
-  Primus.require('util').inherits(Primus, Stream);
+  Primus.requires('util').inherits(Primus, Stream);
 } catch (e) {
   Primus.Stream = EventEmitter;
   Primus.prototype = new EventEmitter();

--- a/transformers/browserchannel/client.js
+++ b/transformers/browserchannel/client.js
@@ -18,7 +18,7 @@ module.exports = function client() {
   var Factory = (function factory() {
     if ('undefined' !== typeof BCSocket) return BCSocket;
 
-    try { return Primus.require('browserchannel').BCSocket; }
+    try { return Primus.requires('browserchannel').BCSocket; }
     catch (e) {}
 
     return undefined;

--- a/transformers/engine.io/client.js
+++ b/transformers/engine.io/client.js
@@ -22,7 +22,7 @@ module.exports = function client() {
   var factory = (function factory() {
     if ('undefined' !== typeof eio) return eio;
 
-    try { return Primus.require('engine.io-client'); }
+    try { return Primus.requires('engine.io-client'); }
     catch (e) {}
 
     return undefined;

--- a/transformers/faye/client.js
+++ b/transformers/faye/client.js
@@ -19,7 +19,7 @@ module.exports = function client() {
     if ('undefined' !== typeof WebSocket) return WebSocket;
     if ('undefined' !== typeof MozWebSocket) return MozWebSocket;
 
-    try { return Primus.require('faye-websocket').Client; }
+    try { return Primus.requires('faye-websocket').Client; }
     catch (e) {}
 
     return undefined;

--- a/transformers/socket.io/client.js
+++ b/transformers/socket.io/client.js
@@ -22,9 +22,9 @@ module.exports = function client() {
   var factory = (function factory() {
     if ('undefined' !== typeof io && io.Socket) return io;
 
-    try { return Primus.require('primus-socket.io-client'); }
+    try { return Primus.requires('primus-socket.io-client'); }
     catch (e) {
-      try { return Primus.require('socket.io-client'); }
+      try { return Primus.requires('socket.io-client'); }
       catch (e) {}
     }
 

--- a/transformers/sockjs/client.js
+++ b/transformers/sockjs/client.js
@@ -18,7 +18,7 @@ module.exports = function client() {
   var Factory = (function Factory() {
     if ('undefined' !== typeof SockJS) return SockJS;
 
-    try { return Primus.require('sockjs-client'); }
+    try { return Primus.requires('sockjs-client'); }
     catch (e) {}
 
     return undefined;

--- a/transformers/websockets/client.js
+++ b/transformers/websockets/client.js
@@ -19,7 +19,7 @@ module.exports = function client() {
     if ('undefined' !== typeof WebSocket) return WebSocket;
     if ('undefined' !== typeof MozWebSocket) return MozWebSocket;
 
-    try { return Primus.require('ws'); }
+    try { return Primus.requires('ws'); }
     catch (e) {}
 
     return undefined;


### PR DESCRIPTION
When using `react-native` with `primus` generated lib will throw error

```
Unable to resolve module stream ....
```

after some debugging I have figured out that `react-native` packager assume that every method with name `require` is normal require method.
So replacing the function name with something else instead of `Primus.require` will fix that problem. 