### PR TITLE
iOS 5 deprecation

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "faye-websocket": "0.11.x",
     "mocha": "2.4.x",
     "pre-commit": "1.1.x",
-    "primus-socket.io-client": "1.0.x",
+    "primus-socket.io-client": "2.0.x",
     "pumpify": "1.3.x",
     "request": "2.69.x",
     "rocambole": "0.7.x",

--- a/transformers/engine.io/library.js
+++ b/transformers/engine.io/library.js
@@ -1,9 +1,5 @@
 (function(f){var g;if(typeof window!=='undefined'){g=window}else if(typeof self!=='undefined'){g=self}g.eio=f()})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(_dereq_,module,exports){
 
-module.exports =  _dereq_('./lib/');
-
-},{"./lib/":2}],2:[function(_dereq_,module,exports){
-
 module.exports = _dereq_('./socket');
 
 /**
@@ -14,7 +10,7 @@ module.exports = _dereq_('./socket');
  */
 module.exports.parser = _dereq_('engine.io-parser');
 
-},{"./socket":3,"engine.io-parser":19}],3:[function(_dereq_,module,exports){
+},{"./socket":2,"engine.io-parser":18}],2:[function(_dereq_,module,exports){
 (function (global){
 /**
  * Module dependencies.
@@ -746,7 +742,7 @@ Socket.prototype.filterUpgrades = function (upgrades) {
 };
 
 }).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./transport":4,"./transports":5,"component-emitter":15,"debug":17,"engine.io-parser":19,"indexof":23,"parsejson":26,"parseqs":27,"parseuri":28}],4:[function(_dereq_,module,exports){
+},{"./transport":3,"./transports":4,"component-emitter":14,"debug":16,"engine.io-parser":18,"indexof":22,"parsejson":25,"parseqs":26,"parseuri":27}],3:[function(_dereq_,module,exports){
 /**
  * Module dependencies.
  */
@@ -903,7 +899,7 @@ Transport.prototype.onClose = function () {
   this.emit('close');
 };
 
-},{"component-emitter":15,"engine.io-parser":19}],5:[function(_dereq_,module,exports){
+},{"component-emitter":14,"engine.io-parser":18}],4:[function(_dereq_,module,exports){
 (function (global){
 /**
  * Module dependencies
@@ -960,7 +956,7 @@ function polling(opts){
 }
 
 }).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./polling-jsonp":6,"./polling-xhr":7,"./websocket":9,"xmlhttprequest-ssl":10}],6:[function(_dereq_,module,exports){
+},{"./polling-jsonp":5,"./polling-xhr":6,"./websocket":8,"xmlhttprequest-ssl":9}],5:[function(_dereq_,module,exports){
 (function (global){
 
 /**
@@ -1202,7 +1198,7 @@ JSONPPolling.prototype.doWrite = function (data, fn) {
 };
 
 }).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./polling":8,"component-inherit":16}],7:[function(_dereq_,module,exports){
+},{"./polling":7,"component-inherit":15}],6:[function(_dereq_,module,exports){
 (function (global){
 /**
  * Module requirements.
@@ -1618,7 +1614,7 @@ function unloadHandler() {
 }
 
 }).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./polling":8,"component-emitter":15,"component-inherit":16,"debug":17,"xmlhttprequest-ssl":10}],8:[function(_dereq_,module,exports){
+},{"./polling":7,"component-emitter":14,"component-inherit":15,"debug":16,"xmlhttprequest-ssl":9}],7:[function(_dereq_,module,exports){
 /**
  * Module dependencies.
  */
@@ -1867,7 +1863,7 @@ Polling.prototype.uri = function(){
   return schema + '://' + (ipv6 ? '[' + this.hostname + ']' : this.hostname) + port + this.path + query;
 };
 
-},{"../transport":4,"component-inherit":16,"debug":17,"engine.io-parser":19,"parseqs":27,"xmlhttprequest-ssl":10,"yeast":30}],9:[function(_dereq_,module,exports){
+},{"../transport":3,"component-inherit":15,"debug":16,"engine.io-parser":18,"parseqs":26,"xmlhttprequest-ssl":9,"yeast":29}],8:[function(_dereq_,module,exports){
 (function (global){
 /**
  * Module dependencies.
@@ -2008,23 +2004,6 @@ WS.prototype.addEventListeners = function(){
 };
 
 /**
- * Override `onData` to use a timer on iOS.
- * See: https://gist.github.com/mloughran/2052006
- *
- * @api private
- */
-
-if ('undefined' != typeof navigator
-  && /iPad|iPhone|iPod/i.test(navigator.userAgent)) {
-  WS.prototype.onData = function(data){
-    var self = this;
-    setTimeout(function(){
-      Transport.prototype.onData.call(self, data);
-    }, 0);
-  };
-}
-
-/**
  * Writes data to socket.
  *
  * @param {Array} array of packets.
@@ -2159,7 +2138,7 @@ WS.prototype.check = function(){
 };
 
 }).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"../transport":4,"component-inherit":16,"debug":17,"engine.io-parser":19,"parseqs":27,"ws":undefined,"yeast":30}],10:[function(_dereq_,module,exports){
+},{"../transport":3,"component-inherit":15,"debug":16,"engine.io-parser":18,"parseqs":26,"ws":undefined,"yeast":29}],9:[function(_dereq_,module,exports){
 // browser shim for xmlhttprequest module
 var hasCORS = _dereq_('has-cors');
 
@@ -2197,7 +2176,7 @@ module.exports = function(opts) {
   }
 }
 
-},{"has-cors":22}],11:[function(_dereq_,module,exports){
+},{"has-cors":21}],10:[function(_dereq_,module,exports){
 module.exports = after
 
 function after(count, callback, err_cb) {
@@ -2227,7 +2206,7 @@ function after(count, callback, err_cb) {
 
 function noop() {}
 
-},{}],12:[function(_dereq_,module,exports){
+},{}],11:[function(_dereq_,module,exports){
 /**
  * An abstraction for slicing an arraybuffer even when
  * ArrayBuffer.prototype.slice is not supported
@@ -2258,7 +2237,7 @@ module.exports = function(arraybuffer, start, end) {
   return result.buffer;
 };
 
-},{}],13:[function(_dereq_,module,exports){
+},{}],12:[function(_dereq_,module,exports){
 /*
  * base64-arraybuffer
  * https://github.com/niklasvh/base64-arraybuffer
@@ -2319,7 +2298,7 @@ module.exports = function(arraybuffer, start, end) {
   };
 })("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/");
 
-},{}],14:[function(_dereq_,module,exports){
+},{}],13:[function(_dereq_,module,exports){
 (function (global){
 /**
  * Create a blob builder even when vendor prefixes exist
@@ -2419,7 +2398,7 @@ module.exports = (function() {
 })();
 
 }).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],15:[function(_dereq_,module,exports){
+},{}],14:[function(_dereq_,module,exports){
 
 /**
  * Expose `Emitter`.
@@ -2585,7 +2564,7 @@ Emitter.prototype.hasListeners = function(event){
   return !! this.listeners(event).length;
 };
 
-},{}],16:[function(_dereq_,module,exports){
+},{}],15:[function(_dereq_,module,exports){
 
 module.exports = function(a, b){
   var fn = function(){};
@@ -2593,7 +2572,7 @@ module.exports = function(a, b){
   a.prototype = new fn;
   a.prototype.constructor = a;
 };
-},{}],17:[function(_dereq_,module,exports){
+},{}],16:[function(_dereq_,module,exports){
 
 /**
  * This is the web browser implementation of `debug()`.
@@ -2763,7 +2742,7 @@ function localstorage(){
   } catch (e) {}
 }
 
-},{"./debug":18}],18:[function(_dereq_,module,exports){
+},{"./debug":17}],17:[function(_dereq_,module,exports){
 
 /**
  * This is the common logic for both the Node.js and web browser
@@ -2962,7 +2941,7 @@ function coerce(val) {
   return val;
 }
 
-},{"ms":25}],19:[function(_dereq_,module,exports){
+},{"ms":24}],18:[function(_dereq_,module,exports){
 (function (global){
 /**
  * Module dependencies.
@@ -3560,7 +3539,7 @@ exports.decodePayloadAsBinary = function (data, binaryType, callback) {
 };
 
 }).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./keys":20,"after":11,"arraybuffer.slice":12,"base64-arraybuffer":13,"blob":14,"has-binary":21,"utf8":29}],20:[function(_dereq_,module,exports){
+},{"./keys":19,"after":10,"arraybuffer.slice":11,"base64-arraybuffer":12,"blob":13,"has-binary":20,"utf8":28}],19:[function(_dereq_,module,exports){
 
 /**
  * Gets the keys for an object.
@@ -3581,7 +3560,7 @@ module.exports = Object.keys || function keys (obj){
   return arr;
 };
 
-},{}],21:[function(_dereq_,module,exports){
+},{}],20:[function(_dereq_,module,exports){
 (function (global){
 
 /*
@@ -3643,7 +3622,7 @@ function hasBinary(data) {
 }
 
 }).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"isarray":24}],22:[function(_dereq_,module,exports){
+},{"isarray":23}],21:[function(_dereq_,module,exports){
 
 /**
  * Module exports.
@@ -3662,7 +3641,7 @@ try {
   module.exports = false;
 }
 
-},{}],23:[function(_dereq_,module,exports){
+},{}],22:[function(_dereq_,module,exports){
 
 var indexOf = [].indexOf;
 
@@ -3673,12 +3652,12 @@ module.exports = function(arr, obj){
   }
   return -1;
 };
-},{}],24:[function(_dereq_,module,exports){
+},{}],23:[function(_dereq_,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
 
-},{}],25:[function(_dereq_,module,exports){
+},{}],24:[function(_dereq_,module,exports){
 /**
  * Helpers.
  */
@@ -3805,7 +3784,7 @@ function plural(ms, n, name) {
   return Math.ceil(ms / n) + ' ' + name + 's';
 }
 
-},{}],26:[function(_dereq_,module,exports){
+},{}],25:[function(_dereq_,module,exports){
 (function (global){
 /**
  * JSON parse.
@@ -3840,7 +3819,7 @@ module.exports = function parsejson(data) {
   }
 };
 }).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],27:[function(_dereq_,module,exports){
+},{}],26:[function(_dereq_,module,exports){
 /**
  * Compiles a querystring
  * Returns string representation of the object
@@ -3879,7 +3858,7 @@ exports.decode = function(qs){
   return qry;
 };
 
-},{}],28:[function(_dereq_,module,exports){
+},{}],27:[function(_dereq_,module,exports){
 /**
  * Parses an URI
  *
@@ -3920,7 +3899,7 @@ module.exports = function parseuri(str) {
     return uri;
 };
 
-},{}],29:[function(_dereq_,module,exports){
+},{}],28:[function(_dereq_,module,exports){
 (function (global){
 /*! https://mths.be/utf8js v2.0.0 by @mathias */
 ;(function(root) {
@@ -4158,7 +4137,7 @@ module.exports = function parseuri(str) {
 }(this));
 
 }).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],30:[function(_dereq_,module,exports){
+},{}],29:[function(_dereq_,module,exports){
 'use strict';
 
 var alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_'.split('')
@@ -4228,5 +4207,9 @@ yeast.encode = encode;
 yeast.decode = decode;
 module.exports = yeast;
 
-},{}]},{},[1])(1)
+},{}],30:[function(_dereq_,module,exports){
+
+module.exports =  _dereq_('./lib/');
+
+},{"./lib/":1}]},{},[30])(30)
 });

--- a/transformers/engine.io/patches/activex.patch
+++ b/transformers/engine.io/patches/activex.patch
@@ -1,8 +1,8 @@
 diff --git a/transformers/engine.io/library.js b/transformers/engine.io/library.js
-index d58aa7b..79f8147 100644
+index 4711309..3200bc9 100644
 --- a/transformers/engine.io/library.js
 +++ b/transformers/engine.io/library.js
-@@ -2013,7 +2013,7 @@ module.exports = function(opts) {
+@@ -2188,7 +2188,7 @@ module.exports = function(opts) {
  
    if (!xdomain) {
      try {

--- a/transformers/engine.io/patches/defer.patch
+++ b/transformers/engine.io/patches/defer.patch
@@ -1,0 +1,28 @@
+diff --git a/transformers/engine.io/library.js b/transformers/engine.io/library.js
+index 3200bc9..aa46cec 100644
+--- a/transformers/engine.io/library.js
++++ b/transformers/engine.io/library.js
+@@ -2004,23 +2004,6 @@ WS.prototype.addEventListeners = function(){
+ };
+ 
+ /**
+- * Override `onData` to use a timer on iOS.
+- * See: https://gist.github.com/mloughran/2052006
+- *
+- * @api private
+- */
+-
+-if ('undefined' != typeof navigator
+-  && /iPad|iPhone|iPod/i.test(navigator.userAgent)) {
+-  WS.prototype.onData = function(data){
+-    var self = this;
+-    setTimeout(function(){
+-      Transport.prototype.onData.call(self, data);
+-    }, 0);
+-  };
+-}
+-
+-/**
+  * Writes data to socket.
+  *
+  * @param {Array} array of packets.

--- a/transformers/engine.io/patches/utf8.patch
+++ b/transformers/engine.io/patches/utf8.patch
@@ -1,8 +1,8 @@
 diff --git a/transformers/engine.io/library.js b/transformers/engine.io/library.js
-index 79f8147..76bb2be 100644
+index aa46cec..4df3e76 100644
 --- a/transformers/engine.io/library.js
 +++ b/transformers/engine.io/library.js
-@@ -3313,17 +3313,7 @@ module.exports = (function() {
+@@ -4120,17 +4120,7 @@ module.exports = function parseuri(str) {
  		'decode': utf8decode
  	};
  

--- a/transformers/socket.io/library.js
+++ b/transformers/socket.io/library.js
@@ -1,5 +1,5 @@
 /*!
- * primus-socket.io.js build: 1.0.1, development.
+ * primus-socket.io.js build: 2.0.0, development.
  * Copyright(c) 2011 LearnBoost <dev@learnboost.com>
  * Copyright (c) 2013 Automattic <dev@cloudup.com>
  * Copyright (c) 2015 contributors of the Primus project, http://primus.io
@@ -27,7 +27,7 @@
    * @api public
    */
 
-  io.version = '1.0.1';
+  io.version = '2.0.0';
 
   /**
    * Protocol implemented.
@@ -2293,7 +2293,7 @@
 
   function WS (socket) {
     io.Transport.apply(this, arguments);
-  };
+  }
 
   /**
    * Inherits from Transport.
@@ -2320,7 +2320,7 @@
   WS.prototype.open = function () {
     var query = io.util.query(this.socket.options.query)
       , self = this
-      , Socket
+      , Socket;
 
 
     if (!Socket) {
@@ -2355,23 +2355,10 @@
    * @api public
    */
 
-  // Do to a bug in the current IDevices browser, we need to wrap the send in a 
-  // setTimeout, when they resume from sleeping the browser will crash if 
-  // we don't allow the browser time to detect the socket has been closed
-  if (io.util.ua.iDevice) {
-    WS.prototype.send = function (data) {
-      var self = this;
-      setTimeout(function() {
-         self.websocket.send(data);
-      },0);
-      return this;
-    };
-  } else {
-    WS.prototype.send = function (data) {
-      this.websocket.send(data);
-      return this;
-    };
-  }
+  WS.prototype.send = function (data) {
+    this.websocket.send(data);
+    return this;
+  };
 
   /**
    * Payload


### PR DESCRIPTION
This completes #404 by removing the workaround for the iOS 5 WebSocket bug from the Socket.IO and Engine.IO client-side libraries.