### PR TITLE
Client: Fix #444: Don't error if there is no `this`

### DIFF
--- a/index.js
+++ b/index.js
@@ -512,14 +512,17 @@ Primus.readable('library', function compile(nodejs) {
   // client.
   //
   client = [
-    '(function UMDish(name, context, definition) {',
+    '(function UMDish(name, context, definition, plugins) {',
     '  context[name] = definition.call(context);',
+    '  for (var i=0; i<plugins.length; i++) {',
+    '    plugins[i](context[name])',
+    '  }',
     '  if (typeof module !== "undefined" && module.exports) {',
     '    module.exports = context[name];',
     '  } else if (typeof define === "function" && define.amd) {',
     '    define(function reference() { return context[name]; });',
     '  }',
-    '})("'+ global +'", this, function wrapper() {',
+    '})("'+ global +'", this || {}, function wrapper() {',
     '  var define, module, exports',
     '    , Primus = '+ client.slice(client.indexOf('return ') + 7, -4) +';',
     ''
@@ -591,16 +594,17 @@ Primus.readable('library', function compile(nodejs) {
   //
   return client + [
     '  return Primus;',
-    '});',
-    ''
+    '},',
+    '['
   ].concat(library.filter(Boolean).map(function expose(library) {
     return [
-      '(function libraryWrap(Primus) {',
+      'function (Primus) {',
       library,
-      '})(this["'+ global +'"]);',
-      ''
+      '}'
     ].join('\n');
-  })).join('\n');
+  }).join(',\n'))
+  .concat(']);')
+  .join('\n');
 });
 
 /**


### PR DESCRIPTION
if this is the case, a module loader is responsible, so we
don't care about exposing a global anyway