### PR TITLE
Remove load dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "eventemitter3": "1.2.x",
     "forwarded-for": "1.0.x",
     "fusing": "1.0.x",
-    "load": "1.0.x",
     "setheader": "0.0.x",
     "ultron": "1.0.x",
     "yeast": "0.1.x"


### PR DESCRIPTION
This patch brings the following changes:

- Use the `vm` module directly instead of depending on `load`.
- Remove the `load` dependency.
- Create a context for the Node.js client where only the required globals are added.

It should fix https://github.com/3rd-Eden/load/issues/4.

I'm actually not sure if it's better to do this in `load` and keep the dependency.