### PR TITLE
Add ability to use transformer specific configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ plugin              | The plugins that should be applied        | `{}`
 timeout             | The heartbeat timeout                     | `35000`
 global              | Set a custom client class / global name   | `Primus`
 compression         | Use permessage-deflate / HTTP compression | `false`
+transport           | Transformer specific configuration        | `{}`
 origins             | **cors** List of origins                  | `*`
 methods             | **cors** List of accepted HTTP methods    | `GET,HEAD,PUT,POST,DELETE,OPTIONS`
 credentials         | **cors** Allow sending of credentials     | `true`
@@ -145,6 +146,13 @@ The options that are prefixed with **cors** are supplied to our
 [access-control](https://github.com/primus/access-control) module which handles
 HTTP Access Control (CORS), so for a more detailed explanation of these options
 check it out.
+
+The `transport` option allows you to use any configuration option supported by
+the underlying real-time framework. Its use is discouraged as these options
+are framework specific and no longer work if you change transformer. Our advise
+is to use it only if you know what you are doing and if you need fine-grained
+control over the real-time framework. Please also keep in mind that some of
+these options are overriden by Primus.
 
 The heartbeat timeout is used to forcefully disconnect a spark if no data is
 received from the client within the specified amount of time. It is possible

--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ function Primus(server, options) {
   }
 
   this.parsers(options.parser);
-  this.initialise(options.transformer || options.transport, options);
+  this.initialise(options.transformer, options);
 
   //
   // If the plugins are supplied through the options, also initialise them.
@@ -253,7 +253,7 @@ Primus.readable('is', function is(what, where) {
 });
 
 /**
- * Initialise the real-time transport that was chosen.
+ * Initialise the real-time engine that was chosen.
  *
  * @param {Mixed} Transformer The name of the transformer or a constructor;
  * @param {Object} options Options.
@@ -271,7 +271,7 @@ Primus.readable('initialise', function initialise(Transformer, options) {
     this.spec.transformer = transformer;
 
     //
-    // This is a unknown transporter, it could be people made a typo.
+    // This is a unknown transformer, it could be people made a typo.
     //
     if (!(Transformer in Primus.transformers)) {
       log('the supplied transformer %s is not supported, please use %s', transformer, Primus.transformers);
@@ -525,7 +525,6 @@ Primus.prototype.spark = function spark(id) {
 Primus.readable('library', function compile(nodejs) {
   var library = [ !nodejs ? this.transformer.library : null ]
     , global = this.options.global || 'Primus'
-    , transport = this.transformer.client
     , parser = this.parser.library || ''
     , client = this.client;
 
@@ -556,7 +555,7 @@ Primus.readable('library', function compile(nodejs) {
   client = client
     .replace('null; // @import {primus::pathname}', '"'+ this.pathname.toString() +'"')
     .replace('null; // @import {primus::version}', '"'+ this.version +'"')
-    .replace('null; // @import {primus::transport}', transport.toString())
+    .replace('null; // @import {primus::client}', this.transformer.client.toString())
     .replace('null; // @import {primus::auth}', (!!this.auth).toString())
     .replace('null; // @import {primus::encoder}', this.encoder.toString())
     .replace('null; // @import {primus::decoder}', this.decoder.toString());

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ function Primus(server, options) {
   }
 
   options = options || {};
+  options.transport = options.transport || {};
   this.fuse();
 
   var primus = this

--- a/primus.js
+++ b/primus.js
@@ -1183,7 +1183,7 @@ Primus.EventEmitter = EventEmitter;
 // These libraries are automatically inserted at the server-side using the
 // Primus#library method.
 //
-Primus.prototype.client = null; // @import {primus::transport};
+Primus.prototype.client = null; // @import {primus::client};
 Primus.prototype.authorization = null; // @import {primus::auth};
 Primus.prototype.pathname = null; // @import {primus::pathname};
 Primus.prototype.encoder = null; // @import {primus::encoder};

--- a/transformers/browserchannel/server.js
+++ b/transformers/browserchannel/server.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var http = require('http');
+var browserchannel = require('browserchannel')
+  , http = require('http');
 
 /**
  * Minimum viable Browserchannel server for Node.js that works through the primus
@@ -10,8 +11,7 @@ var http = require('http');
  * @api private
  */
 module.exports = function server() {
-  var browserchannel = require('browserchannel')
-    , primus = this.primus
+  var primus = this.primus
     , Spark = this.Spark;
 
   //
@@ -19,9 +19,9 @@ module.exports = function server() {
   // automatically announce it self as a new connection once it's created (after
   // the next tick).
   //
-  this.service = browserchannel.server({
+  this.service = browserchannel.server(Object.assign(primus.options.transport, {
     base: primus.pathname
-  }, function connection(socket) {
+  }), function connection(socket) {
     var spark = new Spark(
         socket.headers                          // HTTP request headers.
       , {                                       // IP address Location.

--- a/transformers/engine.io/server.js
+++ b/transformers/engine.io/server.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var Engine = require('engine.io').Server;
+
 /**
  * Minimum viable Engine.IO server for Node.js that works through the primus
  * interface.
@@ -8,13 +10,12 @@
  * @api private
  */
 module.exports = function server() {
-  var Engine = require('engine.io').Server
-    , Spark = this.Spark;
+  var Spark = this.Spark;
 
-  var service = this.service = new Engine({
+  var service = this.service = new Engine(Object.assign({
     perMessageDeflate: !!this.primus.options.compression,
     httpCompression: !!this.primus.options.compression
-  });
+  }, this.primus.options.transport));
 
   //
   // We've received a new connection, create a new Spark. The Spark will

--- a/transformers/faye/server.js
+++ b/transformers/faye/server.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var PrimusError = require('../../errors').PrimusError
+  , Faye = require('faye-websocket')
   , parse = require('url').parse
   , http = require('http');
 
@@ -11,8 +12,7 @@ var PrimusError = require('../../errors').PrimusError
  * @api private
  */
 module.exports = function server() {
-  var Faye = require('faye-websocket')
-    , primus = this.primus
+  var primus = this.primus
     , Spark = this.Spark
     , options = {};
 
@@ -36,6 +36,8 @@ module.exports = function server() {
       throw new PrimusError('Missing dependencies for transformer: "faye"', primus);
     }
   }
+
+  options = Object.assign(options, primus.options.transport);
 
   //
   // Listen to upgrade requests.

--- a/transformers/socket.io/server.js
+++ b/transformers/socket.io/server.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var PrimusError = require('../../errors').PrimusError;
+var PrimusError = require('../../errors').PrimusError
+  , Engine = require('socket.io').Manager;
 
 /**
  * Minimum viable WebSocket server for Node.js that works through the Primus
@@ -10,9 +11,8 @@ var PrimusError = require('../../errors').PrimusError;
  * @api private
  */
 module.exports = function server() {
-  var Engine = require('socket.io').Manager
-    , Spark = this.Spark
-    , primus = this.primus;
+  var primus = this.primus
+    , Spark = this.Spark;
 
   //
   // Socket.IO is not, and will never be supported as long as it's using
@@ -39,7 +39,7 @@ module.exports = function server() {
   //
   // Listen to upgrade requests.
   //
-  var service = this.service = new Engine(this, {
+  var service = this.service = new Engine(this, Object.assign(primus.options.transport, {
     'resource': primus.pathname,
 
     //
@@ -74,7 +74,7 @@ module.exports = function server() {
     // transformers.
     //
     'client store expiration': 0
-  });
+  }));
 
   //
   // We've received a new connection, create a new Spark. The Spark will

--- a/transformers/sockjs/server.js
+++ b/transformers/sockjs/server.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var PrimusError = require('../../errors').PrimusError
-  , parse = require('url').parse;
+  , parse = require('url').parse
+  , sockjs = require('sockjs');
 
 /**
  * Minimum viable Sockjs server for Node.js that works through the primus
@@ -11,8 +12,7 @@ var PrimusError = require('../../errors').PrimusError
  * @api private
  */
 module.exports = function server() {
-  var sockjs = require('sockjs')
-    , primus = this.primus
+  var primus = this.primus
     , prefix = primus.pathname
     , Spark = this.Spark
     , fayeOptions = null;
@@ -77,11 +77,12 @@ module.exports = function server() {
   //
   // Listen to requests.
   //
-  var handle = this.service.listener({
-    faye_server_options: fayeOptions,
+  var handle = this.service.listener(Object.assign({
+    faye_server_options: fayeOptions
+  }, primus.options.transport, {
     log: this.logger.plain,
     prefix: prefix
-  }).getHandler();
+  })).getHandler();
 
   //
   // Here be demons. SockJS has this really horrible "security" feature where it

--- a/transformers/websockets/server.js
+++ b/transformers/websockets/server.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var http = require('http')
-  , parse = require('url').parse;
+var WebSocketServer = require('ws').Server
+  , parse = require('url').parse
+  , http = require('http');
 
 /**
  * Minimum viable WebSocket server for Node.js that works through the Primus
@@ -11,15 +12,15 @@ var http = require('http')
  * @api private
  */
 module.exports = function server() {
-  var WebSocketServer = require('ws').Server
-    , logger = this.logger
+  var logger = this.logger
     , Spark = this.Spark;
 
-  var service = this.service = new WebSocketServer({
-    perMessageDeflate: !!this.primus.options.compression,
+  var service = this.service = new WebSocketServer(Object.assign({
+    perMessageDeflate: !!this.primus.options.compression
+  }, this.primus.options.transport, {
     clientTracking: false,
     noServer: true
-  });
+  }));
 
   /**
    * Noop! Pointless, empty function that will actually be really useful.


### PR DESCRIPTION
This allows to use any configuration option supported by the underlying real-time framework.
There are use cases where this is useful. An example is when you want to limit the max frame size in `ws` or `faye-websocket-node`.

If we don't want this, because it defeats the effortless switching goal, I think that we should at least "wrap" the most important options (`maxPayload`/`maxLength` is one of these imho) like we did with `compression`.