### PR TITLE
Rename some public methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1447,9 +1447,9 @@ of components in Primus are implemented through middleware layers:
 - `no-cache`: Add no-cache headers to every HTTP request.
 - `x-xss`: Add `X-XSS-Protection` headers to every HTTP request.
 
-#### Primus.before(name, fn, options, index)
+#### Primus.use(name, fn, options, index)
 
-The `primus.before` method is how you add middleware layers to your system. All
+The `primus.use` method is how you add middleware layers to your system. All
 middleware layers need to be named. This allows you to also enable, disable and
 remove middleware layers. The supplied function can either be a pre-configured
 function that is ready to answer request/response or an unconfigured
@@ -1458,7 +1458,7 @@ We execute this function automatically with `Primus` as context of the function
 and optionally, the options that got provided:
 
 ```js
-primus.before('name', function () {
+primus.use('name', function () {
   var primus = this;
 
   return function (req, res) {
@@ -1473,12 +1473,12 @@ the function directly:
 
 ```js
 // sync middleware
-primus.before('name', function (req, res) {
+primus.use('name', function (req, res) {
 
 });
 
 // async middleware
-primus.before('name', function (req, res, next) {
+primus.use('name', function (req, res, next) {
   doStuff();
 });
 ```
@@ -1490,7 +1490,7 @@ property to the middleware function and set it to `false` if you don't want it
 to be triggered.
 
 ```js
-primus.before('name', function () {
+primus.use('name', function () {
   function middleware(req, res, next) {
 
   }
@@ -1508,7 +1508,7 @@ argument.
 
 ```js
 // add a middleware after the first two in the stack
-primus.before('name', function (req, res) {
+primus.use('name', function (req, res) {
 
 }, 2);
 ```
@@ -1560,12 +1560,12 @@ Plugins are added on the server side in the form of an `Object`:
 //
 // Require a plugin directly.
 //
-primus.use('name', require('metroplex'));
+primus.plugin('name', require('metroplex'));
 
 //
 // Or supply it manually with the required object structure
 //
-primus.use('name', {
+primus.plugin('name', {
   server: function (primus, options) {},
   client: function (primus, options) {},
   library: 'client side library'
@@ -1594,7 +1594,7 @@ var primus = new Primus(server, { plugin: 'metroplex, primus-emit' })
 To remove added plugins you can use the `plugout` method:
 
 ```js
-primus.use('name', require('metroplex'));
+primus.plugin('name', require('metroplex'));
 primus.plugout('name'); // returns true/false indicating successful removal.
 ```
 
@@ -1656,7 +1656,7 @@ easily add new functionality to the socket. For example adding join room
 function would be as easy as:
 
 ```js
-primus.use('rooms', {
+primus.plugin('rooms', {
   server: function (primus) {
     var Spark = primus.Spark;
 
@@ -1700,7 +1700,7 @@ primus.transform('incoming', function (packet) {
 These transformations can easily be done in the plugins:
 
 ```js
-primus.use('name', {
+primus.plugin('name', {
   server: function (primus) {
     primus.transform('outgoing', function (packet) {
       packet.data = 'foo';

--- a/examples/middleware/index.js
+++ b/examples/middleware/index.js
@@ -59,8 +59,8 @@ var server = http.createServer(app)
 // first will populate `req.signedCookies` and the second `req.session` for the
 // requests captured by Primus.
 //
-primus.before('cookies', cookies);
-primus.before('session', primusSession, { store: store });
+primus.use('cookies', cookies);
+primus.use('session', primusSession, { store: store });
 
 primus.on('connection', function connection(spark) {
   //

--- a/migration.md
+++ b/migration.md
@@ -41,7 +41,7 @@ npm install --save primus-rooms
 After installing you can add the plugin using:
 
 ```js
-primus.use('rooms', require('primus-rooms'));
+primus.plugin('rooms', require('primus-rooms'));
 ```
 
 And now you can join and leave rooms again. Manually leaving rooms when the
@@ -83,5 +83,5 @@ And the only thing we need to do to use it to add the plugin to the Primus
 server using:
 
 ```js
-primus.use('emit', require('primus-emit'));
+primus.plugin('emit', require('primus-emit'));
 ```

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -20,23 +20,23 @@ describe('Middleware', function () {
     primus.destroy(done);
   });
 
-  describe('#before', function () {
+  describe('#use', function () {
     it('is chainable', function () {
-      expect(primus.before('foo', function (req, res) {})).to.equal(primus);
+      expect(primus.use('foo', function (req, res) {})).to.equal(primus);
     });
 
     it('throws when no function is provided', function (done) {
-      try { primus.before('foo', new Date()); }
+      try { primus.use('foo', new Date()); }
       catch (e) { done(); }
     });
 
     it('throws when function doesnt accept req/res args', function (done) {
-      try { primus.before('foo', function () { return function () {}; }); }
+      try { primus.use('foo', function () { return function () {}; }); }
       catch (e) { done(); }
     });
 
     it('calls the function if it has less then 2 arguments', function (done) {
-      primus.before('example', function (options) {
+      primus.use('example', function (options) {
         expect(this).to.equal(primus);
         expect(options).to.be.a('object');
         expect(options.foo).to.equal('bar');
@@ -50,7 +50,7 @@ describe('Middleware', function () {
     it('extracts a name if none is given', function () {
       expect(primus.indexOfLayer('connect')).to.equal(-1);
 
-      primus.before(function connect(req, res, bar) {});
+      primus.use(function connect(req, res, bar) {});
       expect(primus.indexOfLayer('connect')).to.be.above(-1);
     });
 
@@ -58,7 +58,7 @@ describe('Middleware', function () {
       function foo(req, res, next) { }
       function bar(req, res) { }
 
-      primus.before('foo', foo).before('bar', bar);
+      primus.use('foo', foo).use('bar', bar);
 
       var index = primus.indexOfLayer('foo')
         , layer = primus.layers[index];
@@ -77,7 +77,7 @@ describe('Middleware', function () {
       function foo(req, res, next) { }
       function bar(req, res) { }
 
-      primus.before('foo', foo);
+      primus.use('foo', foo);
 
       var index = primus.indexOfLayer('foo')
         , layer = primus.layers[index];
@@ -87,7 +87,7 @@ describe('Middleware', function () {
       expect(layer.length).to.equal(3);
       expect(layer.fn).to.equal(foo);
 
-      primus.before('foo', bar);
+      primus.use('foo', bar);
       expect(primus.indexOfLayer('foo')).to.equal(index);
 
       index = primus.indexOfLayer('foo');
@@ -103,7 +103,7 @@ describe('Middleware', function () {
       function foo(req, res, next) { }
       function bar(req, res, next) { }
 
-      primus.before('foo', foo, 3);
+      primus.use('foo', foo, 3);
 
       var index = primus.indexOfLayer('foo')
         , layer = primus.layers[index];
@@ -114,7 +114,7 @@ describe('Middleware', function () {
       expect(layer.fn).to.equal(foo);
       expect(index).to.equal(3);
 
-      primus.before(bar, 4);
+      primus.use(bar, 4);
 
       index = primus.indexOfLayer('bar');
       layer = primus.layers[index];
@@ -125,7 +125,7 @@ describe('Middleware', function () {
       expect(layer.fn).to.equal(bar);
       expect(index).to.equal(4);
 
-      primus.before(function baz(options) {
+      primus.use(function baz(options) {
         expect(this).to.equal(primus);
         expect(options).to.be.a('object');
         expect(options).to.eql({});
@@ -147,7 +147,7 @@ describe('Middleware', function () {
     it('returns the index based on name', function () {
       expect(primus.indexOfLayer('foo')).to.equal(-1);
 
-      primus.before('foo', function (req, res) {
+      primus.use('foo', function (req, res) {
         throw new Error('Dont execute me');
       });
 
@@ -157,8 +157,8 @@ describe('Middleware', function () {
 
   describe('#remove', function () {
     it('removes the layer from the stack', function () {
-      primus.before('bar', function (req, res) {});
-      primus.before('foo', function (req, res) {
+      primus.use('bar', function (req, res) {});
+      primus.use('foo', function (req, res) {
         throw new Error('boom');
       });
 
@@ -173,7 +173,7 @@ describe('Middleware', function () {
 
   describe('#disable', function () {
     it('disables the middleware', function () {
-      primus.before('foo', function (req, res) {});
+      primus.use('foo', function (req, res) {});
 
       var index = primus.indexOfLayer('foo')
         , layer = primus.layers[index];
@@ -186,7 +186,7 @@ describe('Middleware', function () {
 
   describe('#enable', function () {
     it('enables the middleware', function () {
-      primus.before('foo', function (req, res) {});
+      primus.use('foo', function (req, res) {});
 
       var index = primus.indexOfLayer('foo')
         , layer = primus.layers[index];

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -11,7 +11,7 @@ describe('Plugin', function () {
       , primus = new Primus(server)
       , port = common.port;
 
-    primus.use('emit', {
+    primus.plugin('emit', {
       server: function (primus) {
         primus.transform('incoming', function (packet) {
           var data = packet.data;
@@ -52,7 +52,7 @@ describe('Plugin', function () {
       , primus = new Primus(server)
       , port = common.port;
 
-    primus.use('qs', {
+    primus.plugin('qs', {
       client: function (primus) {
         primus.on('outgoing::url', function (options) {
           options.query = 'foo=bar';
@@ -75,7 +75,7 @@ describe('Plugin', function () {
       , primus = new Primus(server)
       , port = common.port;
 
-    primus.use('spark', {
+    primus.plugin('spark', {
       server: function (primus) {
         var Spark = primus.Spark;
 
@@ -99,7 +99,7 @@ describe('Plugin', function () {
       , server = http.createServer()
       , primus = new Primus(server);
 
-    primus.use('dummy', {
+    primus.plugin('dummy', {
       server: function (primus) {
         primus.Spark.prototype.initialise = function init() {};
       }
@@ -114,7 +114,7 @@ describe('Plugin', function () {
 
     expect(primus.channel).to.be.a('undefined');
 
-    primus.use('spark', {
+    primus.plugin('spark', {
       server: function (primus) {
         primus.channel = function channel() {};
       }
@@ -123,7 +123,7 @@ describe('Plugin', function () {
     expect(primus.channel).to.be.a('function');
   });
 
-  it('emits an `plugin` event when a new plugin is added', function (next) {
+  it('emits a `plugin` event when a new plugin is added', function (next) {
     var server = http.createServer()
       , primus = new Primus(server);
 
@@ -134,9 +134,36 @@ describe('Plugin', function () {
       next();
     });
 
-    primus.use('foo', {
+    primus.plugin('foo', {
       server: function () {}
     });
+  });
+
+  it('allows to get a registered plugin by name', function () {
+    var server = http.createServer()
+      , primus = new Primus(server);
+
+    var plugin = {
+      server: function () {}
+    };
+
+    primus.plugin('spark', plugin);
+    expect(primus.plugin('spark')).to.equal(plugin);
+    expect(primus.plugin('undef')).to.equal(undefined);
+  });
+
+  it('allows to get all registered plugins', function () {
+    var server = http.createServer()
+      , primus = new Primus(server);
+
+    expect(primus.plugin()).to.eql({});
+
+    var plugin = {
+      server: function () {}
+    };
+
+    primus.plugin('spark', plugin);
+    expect(primus.plugin()).to.eql({ spark: plugin });
   });
 
   describe('#plugout', function () {
@@ -151,34 +178,11 @@ describe('Plugin', function () {
         next();
       });
 
-      primus.use('foo', {
+      primus.plugin('foo', {
         server: function () {}
       });
 
       expect(primus.plugout('foo')).to.equal(true);
-    });
-  });
-
-  describe('#plugin', function () {
-    it('returns the plugin for the given name', function () {
-      var server = http.createServer()
-        , primus = new Primus(server);
-
-      var plugin = {
-        server: function () {}
-      };
-
-      primus.use('spark', plugin);
-      expect(primus.plugin('spark')).to.equal(plugin);
-      expect(primus.plugin('undef')).to.equal(undefined);
-    });
-
-    it('returns an empty Object', function () {
-      var server = http.createServer()
-        , primus = new Primus(server);
-
-      expect(primus.plugin()).to.be.a('object');
-      expect(Object.keys(primus.plugin())).to.have.length(0);
     });
   });
 });

--- a/test/primus.test.js
+++ b/test/primus.test.js
@@ -258,20 +258,20 @@ describe('Primus', function () {
     throw new Error('Should have thrown');
   });
 
-  describe('#use', function () {
+  describe('#plugin', function () {
     it('throws an error if no valid name is provided', function () {
-      try { primus.use({}); }
+      try { primus.plugin({}); }
       catch (e) {
         expect(e).to.be.instanceOf(Error);
-        expect(e.message).to.include('Plugin');
-        return expect(e.message).to.include('a name');
+        expect(e.message).to.equal('Plugin name must be a non empty string');
+        return;
       }
 
       throw new Error('Should have thrown');
     });
 
     it('should check if the name is a string', function () {
-      try { primus.use(function () {}); }
+      try { primus.plugin(function () {}); }
       catch (e) {
         expect(e).to.be.instanceOf(Error);
         expect(e.message).to.include('Plugin');
@@ -282,13 +282,13 @@ describe('Primus', function () {
     });
 
     it('doesnt allow duplicate definitions', function () {
-      primus.use('foo', { client: function () {} });
+      primus.plugin('foo', { client: function () {} });
 
-      try { primus.use('foo', { client: function () {} }); }
+      try { primus.plugin('foo', { client: function () {} }); }
       catch (e) {
         expect(e).to.be.instanceOf(Error);
-        expect(e.message).to.include('plugin');
-        return expect(e.message).to.include('defined');
+        expect(e.message).to.equal('Plugin name already defined');
+        return;
       }
 
       throw new Error('Should have thrown');
@@ -297,7 +297,7 @@ describe('Primus', function () {
     it('should have a client or server function', function () {
       var called = 0;
 
-      try { primus.use('cow', { foo: 'bar' }); }
+      try { primus.plugin('cow', { foo: 'bar' }); }
       catch (e) {
         expect(e).to.be.instanceOf(Error);
         expect(e.message).to.include('missing');
@@ -308,9 +308,9 @@ describe('Primus', function () {
 
       expect(called).to.equal(1);
 
-      primus.use('client', { client: function () {} });
-      primus.use('server', { server: function () {} });
-      primus.use('both', { server: function () {}, client: function () {} });
+      primus.plugin('client', { client: function () {} });
+      primus.plugin('server', { server: function () {} });
+      primus.plugin('both', { server: function () {}, client: function () {} });
     });
 
     it('should accept function as second argument', function () {
@@ -318,7 +318,7 @@ describe('Primus', function () {
       Room.server = function (p) { p.foo = 'bar'; };
       Room.client = function () {};
 
-      primus.use('room', Room);
+      primus.plugin('room', Room);
 
       expect(primus.foo).to.equal('bar');
     });
@@ -336,27 +336,26 @@ describe('Primus', function () {
       var b = Object.create(B.prototype);
 
       primus
-      .use('a', a)
-      .use('b', b);
+      .plugin('a', a)
+      .plugin('b', b);
 
       expect(primus.foo).to.equal('bar');
       expect(primus.bar).to.equal('foo');
     });
 
     it('should check if energon is an object or a function', function () {
-      try { primus.use('room'); }
+      try { primus.plugin('room', true); }
       catch (e) {
         expect(e).to.be.instanceOf(Error);
-        expect(e.message).to.include('Plugin');
-        expect(e.message).to.include('object');
-        return expect(e.message).to.include('function');
+        expect(e.message).to.equal('Plugin should be an object or function');
+        return;
       }
 
       throw new Error('Should have thrown');
     });
 
     it('returns this', function () {
-      var x = primus.use('foo', { client: function () {}});
+      var x = primus.plugin('foo', { client: function () {}});
 
       expect(x).to.equal(primus);
     });
@@ -368,7 +367,7 @@ describe('Primus', function () {
     it('calls the supplied server plugin', function (done) {
       var primus = new Primus(server, { foo: 'bar' });
 
-      primus.use('test', {
+      primus.plugin('test', {
         server: function server(pri, options) {
           expect(options).to.be.a('object');
           expect(options.foo).to.equal('bar');
@@ -529,7 +528,7 @@ describe('Primus', function () {
       var primus = new Primus(server)
         , library;
 
-      primus.use('log', { client: function () {
+      primus.plugin('log', { client: function () {
         console.log('i am a client plugin');
       }});
 

--- a/test/transformer.base.js
+++ b/test/transformer.base.js
@@ -1326,7 +1326,7 @@ module.exports = function base(transformer, pathname, transformer_name) {
       });
 
       it('correctly handles requests when a middleware returns an error', function (done) {
-        primus.before('foo', function foo(req, res, next) {
+        primus.use('foo', function foo(req, res, next) {
           next(new Error('foo failed'));
         });
 


### PR DESCRIPTION
This renames `Primus#use` to `Primus#plugin` and `Primus#before` to `Primus#use`.

It is nice to have as these names are better imho but it literally destroys the existing plugin ecosystem.
All plugins need to be updated if this gets merged and they will no longer be compatible with older versions of Primus.

It adds little value to Primus, so we can also keep the existing names and live with it.

Closes #287.
