### PR TITLE
Add msgpack parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "faye-websocket": "0.11.x",
     "mocha": "2.5.x",
     "pre-commit": "1.1.x",
+    "primus-msgpack": "1.0.x",
     "pumpify": "1.3.x",
     "querystringify": "0.0.x",
     "recovery": "0.2.x",

--- a/parsers.json
+++ b/parsers.json
@@ -5,5 +5,8 @@
   },
   "binary": {
     "server": "binary-pack"
+  },
+  "msgpack": {
+    "server": "primus-msgpack"
   }
 }

--- a/parsers/msgpack.js
+++ b/parsers/msgpack.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const msgpack = require('primus-msgpack');
+
+/**
+ * Message encoder.
+ *
+ * @param {Mixed} data The data that needs to be transformed.
+ * @param {Function} fn Completion callback.
+ * @api public
+ */
+exports.encoder = function encoder(data, fn) {
+  var err;
+
+  try { data = msgpack.encode(data); }
+  catch (e) { err = e; }
+
+  fn(err, data);
+};
+
+/**
+ * Message decoder.
+ *
+ * @param {Mixed} data The data that needs to be transformed.
+ * @param {Function} fn Completion callback.
+ * @api public
+ */
+exports.decoder = function decoder(data, fn) {
+  var err;
+
+  try {
+    data = msgpack.decode(data instanceof ArrayBuffer ? new Uint8Array(data) : data);
+  } catch (e) {
+    err = e;
+  }
+
+  fn(err, data);
+};
+
+//
+// Expose the library so it can be added in our Primus module.
+//
+exports.library = `var msgpack = (function () {
+  var exports, mp;
+
+  try { mp = Primus.requires('primus-msgpack'); }
+  catch (e) {}
+
+  if (mp) return mp;
+
+  exports = {};
+  ${msgpack.BrowserSource}
+  return exports.msgpack;
+})();
+`;

--- a/test/primus.parsers.test.js
+++ b/test/primus.parsers.test.js
@@ -60,4 +60,14 @@ describe('Parsers', function () {
       sendsAndReceivesTest('ejson', done);
     });
   });
+
+  describe('msgpack', function () {
+    it('connects with the parser', function (done) {
+      connectsTest('msgpack', done);
+    });
+
+    it('sends and receives data using the parser', function (done) {
+      sendsAndReceivesTest('msgpack', done);
+    });
+  });
 });


### PR DESCRIPTION
This adds an experimental MessagePack parser.
It uses [`msgpack-lite`](https://github.com/kawanet/msgpack-lite) which is quite fast according to the benchmarks.
It could be used as an alternative to `binary-pack` which is incredibly slow when encoding.