### PR TITLE
[fix] Cannot read property 'forwarded' of undefined

### DIFF
--- a/spark.js
+++ b/spark.js
@@ -94,7 +94,7 @@ Spark.writable('__readyState', Spark.OPEN);
 // interested in this, we're going to defer parsing until it's actually needed.
 //
 Spark.get('address', function address() {
-  return this.request.forwarded || forwarded(this.remote, this.headers, this.primus.whitelist);
+  return this.request ? this.request.forwarded : forwarded(this.remote, this.headers, this.primus.whitelist);
 });
 
 /**


### PR DESCRIPTION
Periodically I get an error:
```
TypeError: Cannot read property 'forwarded' of undefined.
    at Sparky.address (/app/node_modules/primus/spark.js:97:22
```

This should address that issue.