### PR TITLE
[fix] Catch closed upgrade requests in `uws`

### DIFF
--- a/transformers/uws/server.js
+++ b/transformers/uws/server.js
@@ -75,7 +75,7 @@ module.exports = function server() {
   this.on('upgrade', (req, soc) => {
     const secKey = req.headers['sec-websocket-key'];
 
-    if (secKey && secKey.length === 24) {
+    if (soc.readable && soc.writable && secKey && secKey.length === 24) {
       soc.setNoDelay(options.transport.noDelay);
 
       let socketHandle = soc._handle;


### PR DESCRIPTION
Fixes #530 

Error handler and checking of readable/writable state is very similar to how this is [done in ws](https://github.com/websockets/ws/blob/95d8553ca657ce926934cd5d8b5eb3c7841f4422/lib/WebSocketServer.js#L150).