### PR TITLE
Reverse the direction of ping/pong messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -438,19 +438,7 @@ Primus.readable('forEach', function forEach(fn, done) {
  */
 Primus.readable('heartbeat', function heartbeat() {
   this.forEach(function forEach(spark) {
-    if (!spark.alive) {
-      //
-      // Set the `reconnect` option to `true` so we don't send a
-      // `primus::server::close` packet to an already broken connection.
-      //
-      spark.end(undefined, { reconnect: true });
-    } else {
-      const now = Date.now();
-
-      spark.alive = false;
-      spark.emit('outgoing::ping', now);
-      spark._write(`primus::ping::${now}`);
-    }
+    spark.heartbeat();
   });
 
   return this;

--- a/spark.js
+++ b/spark.js
@@ -45,8 +45,8 @@ function Spark(primus, headers, address, query, id, request) {
   writable('readable', true);           // Silly stream compatibility.
   writable('queue', []);                // Data queue for data events.
   writable('query', query);             // The query string.
-  writable('timeout', null);            // Heartbeat timeout.
   writable('ultron', new Ultron(this)); // Our event listening cleanup.
+  writable('alive', true);              // Flag used to detect zombie sparks.
 
   //
   // Parse our query string.
@@ -55,7 +55,7 @@ function Spark(primus, headers, address, query, id, request) {
     this.query = parse(this.query);
   }
 
-  this.heartbeat().__initialise.forEach(function execute(initialise) {
+  this.__initialise.forEach(function execute(initialise) {
     initialise.call(spark);
   });
 }
@@ -95,37 +95,6 @@ Spark.writable('__readyState', Spark.OPEN);
 //
 Spark.get('address', function address() {
   return this.request.forwarded || forwarded(this.remote, this.headers, this.primus.whitelist);
-});
-
-/**
- * Set a timer to forcibly disconnect the spark if no data is received from the
- * client within the given timeout.
- *
- * @api private
- */
-Spark.readable('heartbeat', function heartbeat() {
-  var spark = this;
-
-  clearTimeout(spark.timeout);
-
-  if (!spark.primus.options.timeout) return spark;
-
-  log('setting new heartbeat timeout for %s', spark.id);
-
-  this.timeout = setTimeout(function timeout() {
-    //
-    // Set reconnect to true so we're not sending a `primus::server::close`
-    // packet.
-    //
-    spark.end(undefined, { reconnect: true });
-  }, spark.primus.options.timeout);
-
-  //
-  // Emit an event so the application can know the timer has been reset.
-  //
-  spark.emit('heartbeat');
-
-  return this;
 });
 
 /**
@@ -195,12 +164,6 @@ Spark.readable('__initialise', [function initialise() {
   // We've received new data from our client, decode and emit it.
   //
   ultron.on('incoming::data', function message(raw) {
-    //
-    // New data has arrived so we're certain that the connection is still alive,
-    // so it's save to restart the heartbeat sequence.
-    //
-    spark.heartbeat();
-
     primus.decoder.call(spark, raw, function decoding(err, data) {
       //
       // Do a "save" emit('error') when we fail to parse a message. We don't
@@ -221,16 +184,12 @@ Spark.readable('__initialise', [function initialise() {
   });
 
   //
-  // We've received a ping event. This is fired upon receipt of a WebSocket
-  // Ping frame or a `pimus::ping::<timestamp>` message. In the former case
-  // the listener is called without arguments and we should only reset the
-  // heartbeat.
+  // We've received a pong event. This is fired upon receipt of a
+  // `pimus::pong::<timestamp>` message.
   //
-  ultron.on('incoming::ping', function ping(time) {
-    if (time === undefined) return spark.heartbeat();
-
-    spark.emit('outgoing::pong', time);
-    spark._write('primus::pong::'+ time);
+  ultron.on('incoming::pong', function pong() {
+    spark.alive = true;
+    spark.emit('heartbeat');
   });
 
   //
@@ -264,7 +223,6 @@ Spark.readable('__initialise', [function initialise() {
   // End is triggered by both incoming and outgoing events.
   //
   ultron.on('end', function end() {
-    clearTimeout(spark.timeout);
     primus.emit('disconnection', spark);
   });
 
@@ -381,13 +339,13 @@ Spark.readable('protocol', function protocol(msg) {
     , value = msg.slice(last + 2);
 
   switch (msg.slice(8,  last)) {
-    case 'ping':
-      this.emit('incoming::ping', +value);
-    break;
+    case 'pong':
+      this.emit('incoming::pong', +value);
+      break;
 
     case 'id':
       this._write('primus::id::'+ this.id);
-    break;
+      break;
 
     //
     // Unknown protocol, somebody is probably sending `primus::` prefixed

--- a/test/primus.test.js
+++ b/test/primus.test.js
@@ -548,7 +548,7 @@ describe('Primus', function () {
       var primus = new Primus(server, { timeout: 60000 })
         , socket = new primus.Socket('http://localhost:'+ server.portnumber);
 
-      expect(socket.options.ping).to.equal(50000);
+      expect(socket.options.ping).to.equal(90000);
       socket.on('open', socket.end).on('end', function () {
         primus = new Primus(server, { timeout: false });
         socket = primus.Socket('http://localhost:'+ server.portnumber);

--- a/test/primus.test.js
+++ b/test/primus.test.js
@@ -544,29 +544,29 @@ describe('Primus', function () {
       expect(library).to.include('i am a client plugin');
     });
 
-    it('updates the default value of the `ping` option', function (done) {
-      var primus = new Primus(server, { timeout: 60000 })
+    it('updates the default value of the `pingTimeout` option', function (done) {
+      var primus = new Primus(server, { pingInterval: 60000 })
         , socket = new primus.Socket('http://localhost:'+ server.portnumber);
 
-      expect(socket.options.ping).to.equal(90000);
+      expect(socket.options.pingTimeout).to.equal(90000);
       socket.on('open', socket.end).on('end', function () {
-        primus = new Primus(server, { timeout: false });
+        primus = new Primus(server, { pingInterval: false });
         socket = primus.Socket('http://localhost:'+ server.portnumber);
 
-        expect(socket.options.ping).to.equal(false);
+        expect(socket.options.pingTimeout).to.equal(false);
         socket.on('open', socket.end).on('end', done);
       });
     });
 
-    it('still allows overriding the value of the `ping` option', function (done) {
-      var primus = new Primus(server, { timeout: 60000 })
+    it('still allows overriding the value of the `pingTimeout` option', function (done) {
+      var primus = new Primus(server, { pingInterval: 60000 })
         , Socket = primus.Socket;
 
       var socket = new Socket('http://localhost:'+ server.portnumber, {
-        ping: 100
+        pingTimeout: 100
       });
 
-      expect(socket.options.ping).to.equal(100);
+      expect(socket.options.pingTimeout).to.equal(100);
       socket.on('open', socket.end).on('end', done);
     });
 
@@ -574,20 +574,20 @@ describe('Primus', function () {
       var Socket = primus.Socket;
 
       var socket = new Socket({
-        ping: 100,
+        pingTimeout: 100,
         strategy: false,
         manual: true
       });
 
       expect(socket.url).to.eql(socket.parse('http://127.0.0.1'));
-      expect(socket.options.ping).to.equal(100);
+      expect(socket.options.pingTimeout).to.equal(100);
       expect(socket.options.strategy).to.have.length(0);
     });
 
     it('allows option.(url|uri) as url', function () {
       var socket = new primus.Socket({
         url: 'http://google.com',
-        ping: 100,
+        pingTimeout: 100,
         strategy: false,
         manual: true
       });
@@ -596,7 +596,7 @@ describe('Primus', function () {
 
       socket = new primus.Socket({
         uri: 'http://google.com',
-        ping: 100,
+        pingTimeout: 100,
         strategy: false,
         manual: true
       });

--- a/test/spark.test.js
+++ b/test/spark.test.js
@@ -173,9 +173,9 @@ describe('Spark', function () {
     });
   });
 
-  describe('#timeout', function () {
-    it('disconnects if the timeout expires', function (done) {
-      var primus = new Primus(server, { timeout: 25 });
+  describe('#pingInterval', function () {
+    it('disconnects if the client does not respond to a heartbeat', function (done) {
+      var primus = new Primus(server, { pingInterval: 25 });
 
       primus.on('disconnection', function (socket) {
         expect(socket).to.equal(spark);
@@ -287,7 +287,7 @@ describe('Spark', function () {
     });
 
     it('emits `outgoing::ping` when sending a ping', function (done) {
-      var primus = new Primus(server, { timeout: 25 })
+      var primus = new Primus(server, { pingInterval: 25 })
         , spark = new primus.Spark();
 
       spark.on('outgoing::ping', function () {
@@ -298,7 +298,7 @@ describe('Spark', function () {
     });
 
     it('writes `primus::ping::<timestamp>` when sending a ping', function (done) {
-      var primus = new Primus(server, { timeout: 25 })
+      var primus = new Primus(server, { pingInterval: 25 })
         , spark = new primus.Spark();
 
       spark.on('outgoing::ping', function (time) {

--- a/test/spark.test.js
+++ b/test/spark.test.js
@@ -287,7 +287,7 @@ describe('Spark', function () {
     });
 
     it('emits `outgoing::ping` when sending a ping', function (done) {
-      var primus = new Primus(server, { pingInterval: 25 })
+      var primus = new Primus(server, { pingInterval: 10 })
         , spark = new primus.Spark();
 
       spark.on('outgoing::ping', function () {
@@ -298,7 +298,7 @@ describe('Spark', function () {
     });
 
     it('writes `primus::ping::<timestamp>` when sending a ping', function (done) {
-      var primus = new Primus(server, { pingInterval: 25 })
+      var primus = new Primus(server, { pingInterval: 10 })
         , spark = new primus.Spark();
 
       spark.on('outgoing::ping', function (time) {
@@ -308,6 +308,23 @@ describe('Spark', function () {
             primus.destroy(done);
           });
         });
+      });
+    });
+
+    it('allows overwriting heartbeat fn', function (done) {
+      var primus = new Primus(server, { pingInterval: 10 })
+        , spark = new primus.Spark();
+
+      var called = false;
+      spark.heartbeat = function() {
+        called = true;
+        spark.emit('outgoing::ping');
+      };
+
+      spark.on('outgoing::ping', function (time) {
+        expect(called).to.equal(true);
+        expect(time).to.equal(undefined);
+        primus.destroy(done);
       });
     });
   });

--- a/test/transformer.base.js
+++ b/test/transformer.base.js
@@ -1329,8 +1329,8 @@ module.exports = function base(transformer, transformer_name) {
           expect(body.transformer).to.equal(transformer);
           expect(body.version).to.equal(primus.version);
           expect(body.pathname).to.equal('/primus');
+          expect(body.pingInterval).to.equal(30000);
           expect(body.parser).to.equal('json');
-          expect(body.timeout).to.equal(35000);
           done();
         });
       });

--- a/transformers/uws/server.js
+++ b/transformers/uws/server.js
@@ -69,7 +69,7 @@ module.exports = function server() {
     spark.emit('incoming::data', msg);
   });
 
-  native.server.group.onPing(group, (msg, spark) => spark.emit('incoming::ping'));
+  native.server.group.onPing(group, (msg, spark) => spark.emit('incoming::pong'));
 
   //
   // Listen to upgrade requests.

--- a/transformers/websockets/server.js
+++ b/transformers/websockets/server.js
@@ -51,9 +51,6 @@ module.exports = function server() {
 
       socket.on('message', spark.emits('incoming::data'));
       socket.on('error', spark.emits('incoming::error'));
-      socket.on('ping', spark.emits('incoming::ping', (next) => {
-        next(undefined, null);
-      }));
       socket.on('close', spark.emits('incoming::end', (next) => {
         socket.removeAllListeners();
         socket = null;

--- a/transformers/websockets/server.js
+++ b/transformers/websockets/server.js
@@ -51,6 +51,9 @@ module.exports = function server() {
 
       socket.on('message', spark.emits('incoming::data'));
       socket.on('error', spark.emits('incoming::error'));
+      socket.on('ping', spark.emits('incoming::pong', (next) => {
+        next(undefined, null);
+      }));
       socket.on('close', spark.emits('incoming::end', (next) => {
         socket.removeAllListeners();
         socket = null;


### PR DESCRIPTION
This reverses the direction of ping/pong messages. Ping messages are now sent from server to client to work around issues generated by throttled timers on modern browsers.