### PR TITLE
Issue 579 Don't start heartbeat in createSocket

### DIFF
--- a/index.js
+++ b/index.js
@@ -1092,7 +1092,7 @@ Primus.prototype.reserved.events = {
  * @api public
  */
 Primus.createSocket = function createSocket(options) {
-  options = options || {};
+  options = Primus.prototype.merge.call(Primus, {}, options || {});
   // Make sure the temporary Primus we create below doesn't start a heartbeat
   options.pingInterval = false;
 

--- a/index.js
+++ b/index.js
@@ -1094,9 +1094,7 @@ Primus.prototype.reserved.events = {
 Primus.createSocket = function createSocket(options) {
   options = options || {};
   // Make sure the temporary Primus we create below doesn't start a heartbeat
-  options.pingInterval = 'pingInterval' in options
-    ? options.pingInterval
-    : false;
+  options.pingInterval = false;
 
   var primus = new Primus(new EventEmitter(), options);
   return primus.Socket;

--- a/index.js
+++ b/index.js
@@ -1093,6 +1093,10 @@ Primus.prototype.reserved.events = {
  */
 Primus.createSocket = function createSocket(options) {
   options = options || {};
+  // Make sure the temporary Primus we create below doesn't start a heartbeat
+  options.pingInterval = 'pingInterval' in options
+    ? options.pingInterval
+    : false;
 
   var primus = new Primus(new EventEmitter(), options);
   return primus.Socket;

--- a/index.js
+++ b/index.js
@@ -1092,9 +1092,8 @@ Primus.prototype.reserved.events = {
  * @api public
  */
 Primus.createSocket = function createSocket(options) {
-  options = Primus.prototype.merge.call(Primus, {}, options || {});
   // Make sure the temporary Primus we create below doesn't start a heartbeat
-  options.pingInterval = false;
+  options = Object.assign({}, options, { pingInterval: false });
 
   var primus = new Primus(new EventEmitter(), options);
   return primus.Socket;

--- a/test/transformer.base.js
+++ b/test/transformer.base.js
@@ -900,19 +900,21 @@ module.exports = function base(transformer, transformer_name) {
       });
 
       it('should not start heartbeat', function (done) {
-        var num_handles_before = process._getActiveHandles().length
-          , PSocket = Primus.createSocket({
-              transformer: transformer,
-              pathname: server.pathname
-            })
-          , num_handles_after = process._getActiveHandles().length
-          , socket = new PSocket(server.addr);
-
-        expect(num_handles_after).to.equal(num_handles_before);
-        socket.on('open', function () {
-          socket.end();
+        var orig_setInterval = setInterval
+          , called = false;
+        setInterval = function () {
+          called = true;
+        };
+        Primus.createSocket({
+          transformer: transformer,
+          pathname: server.pathname
+        })
+        setInterval = orig_setInterval;
+        if (called) {
+          done(new Error('createSocket should not start a heartbeat'));
+        } else {
           done();
-        });
+        }
       });
     });
 

--- a/test/transformer.base.js
+++ b/test/transformer.base.js
@@ -898,6 +898,22 @@ module.exports = function base(transformer, transformer_name) {
           done();
         });
       });
+
+      it('should not start heartbeat', function (done) {
+        var num_handles_before = process._getActiveHandles().length
+          , PSocket = Primus.createSocket({
+              transformer: transformer,
+              pathname: server.pathname
+            })
+          , num_handles_after = process._getActiveHandles().length
+          , socket = new PSocket(server.addr);
+
+        expect(num_handles_after).to.equal(num_handles_before);
+        socket.on('open', function () {
+          socket.end();
+          done();
+        });
+      });
     });
 
     describe('Authorization', function () {

--- a/test/transformer.base.js
+++ b/test/transformer.base.js
@@ -901,15 +901,19 @@ module.exports = function base(transformer, transformer_name) {
 
       it('should not start heartbeat', function (done) {
         var orig_setInterval = setInterval
-          , called = false;
+          , called = false
+          , options = {
+              transformer: transformer,
+              pathname: server.pathname,
+              pingInterval: 60000
+            };
         setInterval = function () {
           called = true;
         };
-        Primus.createSocket({
-          transformer: transformer,
-          pathname: server.pathname
-        })
+        Primus.createSocket(options);
+        Primus.createSocket();
         setInterval = orig_setInterval;
+        expect(options.pingInterval).to.equal(60000);
         if (called) {
           done(new Error('createSocket should not start a heartbeat'));
         } else {


### PR DESCRIPTION
#579 

Test uses `process._getActiveHandles()` to check `setInterval()` wasn't called.
Alternative would be to mock `setInterval`.