### PR TITLE
Fixes on typescript def

### DIFF
--- a/primus.d.ts
+++ b/primus.d.ts
@@ -1,6 +1,11 @@
 import * as http from 'http';
 import { Socket } from 'net';
 
+export interface IPrimusParser {
+  encoder: (data: any, fn: (error: Error, response: any) => void) => void;
+  decoder: (data: any, fn: (error: Error, response: any) => void) => void;
+}
+
 export declare class Primus {
   constructor(server: http.Server, options?: IPrimusOptions);
   authorize(req: http.ClientRequest, done: () => void): void;
@@ -36,12 +41,13 @@ export interface IPrimusOptions {
   maxAge?: string;
   methods?: string;
   origins?: string;
-  parser?: string;
+  parser?: string | IPrimusParser;
   pathname?: string;
   plugin?: Object;
   strategy?: any;
   timeout?: number;
   transformer?: string;
+  [key: string]: any;
 }
 
 export interface IPrimusConnectOptions {


### PR DESCRIPTION
Two fixes on typescript definitions :

- `parser` can be a string or an object with the `encoder` and `decoder` functions
- Allow other properties like `middleware` or `redis`, etc. (for plugin like metroplex)