### PR TITLE
chore(readme): Update cluster section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2045,18 +2045,13 @@ primacron can be time savers.
 
 #### Can I use cluster?
 
-The `cluster` module that ships with Node.js is flawed, seriously flawed.
-Cluster in node < 0.12.0 lets the Operating System decide which worker process
-should receive the request. This results in a not even distribution across
-the workers. If you have 3 workers, it's possible that one is used at 70%,
-another at 20% and the last one at 10%. This is of course not wanted when using
-a cluster. In addition, the load balancing done by the OS is not sticky.
+> Note: The following only applies to websocket emulation transformers like
+> socket.io or engine.io. If you are using `ws` or `uws`, there is no need
+> for sticky sessions, and thus no issue.
 
-Cluster in node >= 0.12.0 implements a custom round robin algorithm in order to
-fix this un-even distribution of the load across the workers, but it does not
-address the sticky session requirement.
+The `cluster` module that ships with Node.js does not implement sticky sessions.
 
-There are also projects like `stick-session` which attempt to implement
+There are projects like `stick-session` which attempt to implement
 sticky-sessions in cluster, but the problem with this specific approach is that
 it uses the `remoteAddress` of the connection. For some people this isn't a
 problem but when you add this behind a load balancer the remote address will be
@@ -2067,6 +2062,10 @@ Primus library is run in a worker environment. **USE IT AT YOUR OWN RISK**.
 
 To turn off the cluster warning in your Primus instance you can set the option
 `iknowclusterwillbreakconnections` to `true`.
+
+See [metroplex](https://www.npmjs.com/package/metroplex) and
+[primus-cluster](https://www.npmjs.com/package/primus-cluster) for some ideas
+of how to properly cluster Primus.
 
 #### How do I use Primus with Express
 


### PR DESCRIPTION
Now that our compatibility matrix is Node >=4, there's no need
for the 0.10 warning. Additionally, sticky sessions are not an
issue if you're just using real sockets (and not emulation).