### PR TITLE
End upgrade connection rather than destroy #691

### DIFF
--- a/middleware/authorization.js
+++ b/middleware/authorization.js
@@ -37,8 +37,6 @@ module.exports = function configuration() {
         if (code === 401 && err.authenticate) {
           res.setHeader('WWW-Authenticate', err.authenticate);
         }
-
-        res.end(message);
       } else {
         res.write('HTTP/'+ req.httpVersion +' ');
         res.write(code +' '+ require('http').STATUS_CODES[code] +'\r\n');
@@ -51,9 +49,9 @@ module.exports = function configuration() {
         }
 
         res.write('\r\n');
-        res.write(message);
-        res.destroy();
       }
+
+      res.end(message);
     });
   };
 };


### PR DESCRIPTION
#691 Calling destroy on the socket can mean the headers and message don't get away before the socket is destroyed.

Node doc for socket.destroy says:

    Ensures that no more I/O activity happens on this socket.

Node doc for socket.end says:

    Half-closes the socket. i.e., it sends a FIN packet.

