### PR TITLE
Expose transformers server and sparks underlying socket

### DIFF
--- a/spark.js
+++ b/spark.js
@@ -22,9 +22,10 @@ var ParserError = require('./errors').ParserError
  * @param {Object} query The query string of request.
  * @param {String} id An optional id of the socket, or we will generate one.
  * @param {Request} request The HTTP Request instance that initialised the spark.
+ * @param {Mixed} socket Reference to the transformer's socket
  * @api public
  */
-function Spark(primus, headers, address, query, id, request) {
+function Spark(primus, headers, address, query, id, request, socket) {
   this.fuse();
 
   var writable = this.writable
@@ -42,6 +43,7 @@ function Spark(primus, headers, address, query, id, request) {
   writable('remote', address);          // The remote address location.
   writable('headers', headers);         // The request headers.
   writable('request', request);         // Reference to an HTTP request.
+  writable('socket', socket);           // Reference to the transformer's socket
   writable('writable', true);           // Silly stream compatibility.
   writable('readable', true);           // Silly stream compatibility.
   writable('queue', []);                // Data queue for data events.

--- a/transformers/browserchannel/server.js
+++ b/transformers/browserchannel/server.js
@@ -30,8 +30,9 @@ module.exports = function server() {
         }
       , socket.query                            // Optional query string.
       , socket.id                               // Unique connection id.
+      , null                                    // We don't have have a HTTP request
+      , socket                                  // Reference to transformers socket
     );
-    spark.socket = socket;
 
     spark.on('outgoing::end', function end() {
       if (socket) socket.stop();

--- a/transformers/browserchannel/server.js
+++ b/transformers/browserchannel/server.js
@@ -31,6 +31,7 @@ module.exports = function server() {
       , socket.query                            // Optional query string.
       , socket.id                               // Unique connection id.
     );
+    spark.socket = socket;
 
     spark.on('outgoing::end', function end() {
       if (socket) socket.stop();

--- a/transformers/engine.io/server.js
+++ b/transformers/engine.io/server.js
@@ -29,6 +29,7 @@ module.exports = function server() {
       , socket.id               // Unique connection id.
       , socket.request          // Reference to the HTTP req.
     );
+    spark.socket = socket;
 
     spark.on('outgoing::end', () => socket && socket.close());
     spark.on('outgoing::data', (data) => socket.write(data));

--- a/transformers/engine.io/server.js
+++ b/transformers/engine.io/server.js
@@ -28,8 +28,8 @@ module.exports = function server() {
       , socket.request.query    // Optional query string.
       , socket.id               // Unique connection id.
       , socket.request          // Reference to the HTTP req.
+      , socket                  // Reference to transformers socket
     );
-    spark.socket = socket;
 
     spark.on('outgoing::end', () => socket && socket.close());
     spark.on('outgoing::data', (data) => socket.write(data));

--- a/transformers/faye/server.js
+++ b/transformers/faye/server.js
@@ -58,6 +58,7 @@ module.exports = function server() {
         , null                      // We don't have an unique id.
         , req                       // Reference to the HTTP req.
       );
+      spark.socket = websocket;
 
       spark.on('outgoing::end', () => websocket && websocket.close());
       spark.on('outgoing::data', (data) => websocket.send(data));

--- a/transformers/faye/server.js
+++ b/transformers/faye/server.js
@@ -58,7 +58,7 @@ module.exports = function server() {
         , null                      // We don't have an unique id.
         , req                       // Reference to the HTTP req.
       );
-      spark.socket = websocket;
+      spark.socket = socket;
 
       spark.on('outgoing::end', () => websocket && websocket.close());
       spark.on('outgoing::data', (data) => websocket.send(data));

--- a/transformers/faye/server.js
+++ b/transformers/faye/server.js
@@ -57,8 +57,8 @@ module.exports = function server() {
         , url.parse(req.url).query  // Optional query string.
         , null                      // We don't have an unique id.
         , req                       // Reference to the HTTP req.
+        , websocket                 // Reference to transformers socket
       );
-      spark.socket = socket;
 
       spark.on('outgoing::end', () => websocket && websocket.close());
       spark.on('outgoing::data', (data) => websocket.send(data));

--- a/transformers/sockjs/server.js
+++ b/transformers/sockjs/server.js
@@ -58,8 +58,9 @@ module.exports = function server() {
       , socket                       // IP address location.
       , url.parse(socket.url).query  // Optional query string.
       , socket.id                    // Unique connection id.
+      , null                         // We don't have have a HTTP request
+      , socket                       // Reference to transformers socket
     );
-    spark.socket = socket;
 
     spark.on('outgoing::end', () => socket && socket.close());
     spark.on('outgoing::data', (data) => socket.write(data));

--- a/transformers/sockjs/server.js
+++ b/transformers/sockjs/server.js
@@ -59,6 +59,7 @@ module.exports = function server() {
       , url.parse(socket.url).query  // Optional query string.
       , socket.id                    // Unique connection id.
     );
+    spark.socket = socket;
 
     spark.on('outgoing::end', () => socket && socket.close());
     spark.on('outgoing::data', (data) => socket.write(data));

--- a/transformers/uws/server.js
+++ b/transformers/uws/server.js
@@ -23,7 +23,7 @@ module.exports = function server() {
     maxPayload: this.primus.options.maxLength
   }, this.primus.options.transport);
 
-  this.uWsServer = native.server;
+  this.service = native.server;
 
   let flags = 0;
 
@@ -49,7 +49,6 @@ module.exports = function server() {
     native.setUserData(socket, spark);
 
     spark.ultron.on('outgoing::end', () => native.server.close(socket));
-    spark._socket = socket;
     spark.on('outgoing::data', (data) => {
       const opcode = Buffer.isBuffer(data)
         ? uws.OPCODE_BINARY

--- a/transformers/uws/server.js
+++ b/transformers/uws/server.js
@@ -43,9 +43,9 @@ module.exports = function server() {
       upgradeReq,                       // IP address location.
       url.parse(upgradeReq.url).query,  // Optional query string.
       null,                             // We don't have an unique id.
-      upgradeReq                        // Reference to the HTTP req.
+      upgradeReq,                       // Reference to the HTTP req.
+      socket                            // Reference to transformers socket
     );
-    spark.socket = socket;
 
     native.setUserData(socket, spark);
 

--- a/transformers/uws/server.js
+++ b/transformers/uws/server.js
@@ -45,6 +45,7 @@ module.exports = function server() {
       null,                             // We don't have an unique id.
       upgradeReq                        // Reference to the HTTP req.
     );
+    spark.socket = socket;
 
     native.setUserData(socket, spark);
 

--- a/transformers/uws/server.js
+++ b/transformers/uws/server.js
@@ -23,6 +23,8 @@ module.exports = function server() {
     maxPayload: this.primus.options.maxLength
   }, this.primus.options.transport);
 
+  this.uWsServer = native.server;
+
   let flags = 0;
 
   if (opts.perMessageDeflate) {
@@ -47,6 +49,7 @@ module.exports = function server() {
     native.setUserData(socket, spark);
 
     spark.ultron.on('outgoing::end', () => native.server.close(socket));
+    spark._socket = socket;
     spark.on('outgoing::data', (data) => {
       const opcode = Buffer.isBuffer(data)
         ? uws.OPCODE_BINARY

--- a/transformers/websockets/server.js
+++ b/transformers/websockets/server.js
@@ -39,8 +39,8 @@ module.exports = function server() {
         , url.parse(req.url).query  // Optional query string.
         , null                      // We don't have an unique id.
         , req                       // Reference to the HTTP req.
+        , socket                    // Reference to transformers socket
       );
-      spark.socket = socket;
 
       spark.on('outgoing::end', () => socket && socket.close());
       spark.on('outgoing::data', (data) => {

--- a/transformers/websockets/server.js
+++ b/transformers/websockets/server.js
@@ -40,6 +40,7 @@ module.exports = function server() {
         , null                      // We don't have an unique id.
         , req                       // Reference to the HTTP req.
       );
+      spark.socket = socket;
 
       spark.on('outgoing::end', () => socket && socket.close());
       spark.on('outgoing::data', (data) => {


### PR DESCRIPTION
Over the past two days I've been trying to improve performance of my stack as much as possible, going as far as writing my own much simpler rooms extension and entirely stepping trough function calls. Having `primus.encoder.call` being called only once instead of per client whenever you emit to multiple clients at once in itself already gave me a massive peformance boost, and is implementable without modifying any core code, however there was a second step involved which I took and that is using uWs' `prepareMessage` / `sendPrepared` calls. This gave me yet another significant boost in troughput.

My plugin should be rather versatile, tho surely not fully compatible with all setups, however I feel like it should be a great addition to release. It would work without the modifications of this PR, however uWs users would miss out on an extra boost in performance (around 25x from my tests when writing a 120 kbyte msgpack to 600 clients), and I dont see any issue with exposing these things.