### PR TITLE
Add socket parameter in Spark constructor wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,11 @@ The `spark.query` contains the query string you used to connect to the server. I
 parsed as an object. Please note that this may not be available for all supported
 transformers.
 
+#### spark.socket
+
+The `spark.socket` is set to the underlying socket of the transformer. This is not
+necessarily a raw `Socket` and will differ from transformer to transformer.
+
 #### spark.id
 
 This is a unique id that we use to identify this single connection with. Normally

--- a/index.js
+++ b/index.js
@@ -82,8 +82,8 @@ function Primus(server, options) {
   // approach listed below is that the prototype extensions are only applied to
   // the Spark of this Primus instance.
   //
-  this.Spark = function Sparky(headers, address, query, id, request) {
-    Spark.call(this, primus, headers, address, query, id, request);
+  this.Spark = function Sparky(headers, address, query, id, request, socket) {
+    Spark.call(this, primus, headers, address, query, id, request, socket);
   };
 
   this.Spark.prototype = Object.create(Spark.prototype, {

--- a/test/transformer.base.js
+++ b/test/transformer.base.js
@@ -1239,7 +1239,7 @@ module.exports = function base(transformer, transformer_name) {
 
       it('should expose transformers socket', function (done) {
         primus.on('connection', function (spark) {
-          expect(spark.socket).to.be.ok();
+          expect(spark.socket).to.not.equal(undefined);
 
           socket.end();
         });

--- a/test/transformer.base.js
+++ b/test/transformer.base.js
@@ -1237,6 +1237,17 @@ module.exports = function base(transformer, transformer_name) {
         socket.on('end', done);
       });
 
+      it('should expose transformers socket', function (done) {
+        primus.on('connection', function (spark) {
+          expect(spark.socket).to.be.ok();
+
+          socket.end();
+        });
+
+        var socket = new Socket(server.make_addr(null, null));
+        socket.on('end', done);
+      });
+
       it('should receive querystrings', function (done) {
         primus.on('connection', function (spark) {
           expect(spark.query).to.be.a('object');


### PR DESCRIPTION
Just finally got around to change my proprietary rooms plugin implementation to one I could actually release and realized I failed to add the new socket variable introduced w/ #703 here, thus it always ending up "undefined". Oops, should've tested in advance, sorry!