### PR TITLE
[fix] Prevent "Cannot read property 'headers' of null"

### DIFF
--- a/transformers/sockjs/server.js
+++ b/transformers/sockjs/server.js
@@ -48,6 +48,9 @@ module.exports = function server() {
   // the next tick).
   //
   this.service.on('connection', (socket) => {
+    if (!socket) {
+      return;  
+    }
     const headers = socket.headers.via;
 
     headers.via = headers._via;


### PR DESCRIPTION
Apparently there is an unidentified bug in SockJS whereby the connection object received in the 'connection' event handler is sometimes null. This has started to happen to us when we upgraded to Node v14 (from v10) and it has happened in production a few times already causing the entire server to collapse.
Please see https://github.com/sockjs/sockjs-node/issues/121 and also https://github.com/webpack/webpack-dev-server/commit/79649971c299f648fdd0ba3d4513a8cf7fc881d2 where webpack-dev-server implements a similar fix.